### PR TITLE
implement a wrapper function to mark functions/classes as deprecated

### DIFF
--- a/GTC/deprecated.py
+++ b/GTC/deprecated.py
@@ -312,7 +312,14 @@ def _warn(message,
 
     All other keyword arguments are defined in :func:`deprecated`.
     """
-    if action:
+    # When specifying the action, the catch_warnings() context manager allows
+    # the warning behavior to be modified when entering the context and is
+    # restored when exiting. Using the context manager is required so that the
+    # application's global context is not modified. In the case of "once", this
+    # has the effect of restoring the internal call counter, so a warning message
+    # is issued every time the line issuing the warning is called. Therefore,
+    # for action="once" we treat it equivalent to not specifying the action.
+    if action and action != 'once':
         with warnings.catch_warnings():
             warnings.simplefilter(action, category)
             warnings.warn(message, category=category, stacklevel=stacklevel)

--- a/GTC/deprecated.py
+++ b/GTC/deprecated.py
@@ -4,6 +4,7 @@ as a decorator to mark a function, class or method as deprecated.
 """
 import functools
 import inspect
+import os
 import re
 import sys
 import textwrap
@@ -13,7 +14,8 @@ from GTC import version
 
 PY2 = sys.version_info.major == 2
 
-_running_tests = 'unittest' in sys.modules
+# This environment variable is defined in conftest.py when pytest runs the tests
+_running_tests = os.getenv('GTC_RUNNING_TESTS', 'false') == 'true'
 
 # Strip Sphinx cross-reference syntax (like ":class:" and ":py:func:") from
 # warning messages that are passed to warnings.warn(). The format of the syntax
@@ -106,10 +108,12 @@ def deprecated(*args, **kwargs):
 
         remove_in : str or None
             The version that the wrapped object is planned to be removed in.
-            If the tests are running and the version of GTC is greater than
-            or equal to the `remove_in` value, an exception is raised when
-            `@deprecated` is called (not when the wrapped object is called).
-            Default is None.
+            If the tests are running (i.e., a GTC_RUNNING_TESTS environment
+            variable is set to be "true") and the version of GTC is greater
+            than or equal to the `remove_in` value, an exception is raised
+            when @deprecated` is called (not when the wrapped object is
+            called), which occurs when the module that contains the deprecated
+            object gets imported. Default is None.
 
         stacklevel : int
             Number of frames up the stack that issued the warning. Default is 3.

--- a/GTC/deprecated.py
+++ b/GTC/deprecated.py
@@ -71,7 +71,7 @@ def deprecated(*args, **kwargs):
 
         action : str or None
             The type of filter to use when the warning is issued. One of
-            "always", "default", "error", "ignore", "module" or "once".
+            "always", "default", "error", "ignore" or "once".
             If None, the global warning-filter setting is used. Default is None.
             See https://docs.python.org/3/library/warnings.html#the-warnings-filter
 
@@ -248,6 +248,9 @@ def _prepare_warning(wrapped,
             'Dear GTC developer, you are still using a {} that '
             'should be removed:\n{}'.format(kind, message)
         )
+
+    if action == 'module':
+        raise ValueError('Using action="module" is not supported')
 
     warn_kw = {'action': action, 'category': category, 'stacklevel': stacklevel}
     return message, warn_kw

--- a/GTC/deprecated.py
+++ b/GTC/deprecated.py
@@ -50,8 +50,8 @@ def deprecated(*args, **kwargs):
     """Use as a decorator to mark a function, class or method as deprecated.
 
     :param args: The number of positional arguments may be either zero or one.
-        If one, then either the callable object that is marked as deprecated
-        or the reason (as a string) why the object is marked as deprecated.
+        If one, then it must be the reason (as a string) why the object is
+        marked as deprecated.
 
         Examples,
 

--- a/GTC/deprecated.py
+++ b/GTC/deprecated.py
@@ -1,0 +1,302 @@
+"""
+This module contains a `deprecated` function that may be used
+to mark a function, class or method as deprecated.
+"""
+import functools
+import inspect
+import re
+import sys
+import textwrap
+import warnings
+
+from GTC import version
+
+PY2 = sys.version_info.major == 2
+
+_running_tests = 'unittest' in sys.modules
+
+# Strip Sphinx cross-reference syntax (like ":function:" and ":py:func:")
+# from warning messages that are written to stdout. The format of the syntax
+# are ":role:`foo`", ":domain:role:`foo`", where ``role`` and ``domain``
+# match "[a-zA-Z]+"
+_regex_remove_role = re.compile(
+    r'(?: : [a-zA-Z]+ )? : [a-zA-Z]+ : (`[^`]*`)', flags=re.X)
+
+
+__all__ = (
+    'GTCDeprecationWarning',
+    'deprecated',
+)
+
+
+class GTCDeprecationWarning(UserWarning):
+    """
+    By default, Python will not show a DeprecationWarning because it
+    is ignored by the default warning-filter settings. Inheriting from
+    UserWarning, instead of DeprecationWarning, allows for the warning
+    to be displayed more reliably.
+
+    DeprecationWarning is meant for internal use by the Python developers.
+    From the Python documentation:
+
+        Base category for warnings about deprecated features when those
+        warnings are intended for other Python developers (ignored by
+        default, unless triggered by code in __main__).
+
+    """
+
+
+def deprecated(*args, **kwargs):
+    """Use as a decorator to mark a function, class or method as deprecated.
+
+    :param args: The number of positional arguments may be either zero or one.
+        If one, then either the callable object that is marked as deprecated
+        or the reason (as a string) why the object is marked as deprecated.
+
+        Examples,
+
+            @deprecated
+            def foo():
+
+            @deprecated()
+            def foo():
+
+            @deprecated('Use :func:`bar` instead')
+            def foo():
+
+    :param kwargs: The following keyword arguments may be specified.
+
+        action : str or None
+            The type of simple-warning filter to use. One of "error",
+            "ignore", "always", "default", "module", or "once". If None,
+            then the global-warning-filter setting is used. Default is None.
+
+        category : Type[Warning]
+            The type of Warning class to use. Default is GTCDeprecationWarning.
+
+        deprecated_in : str or None
+            The version that the wrapped object became deprecated in.
+            Default is None.
+
+        docstring_line_width: int
+            The maximum line width of the deprecation message that gets
+            appended to the docstring of the wrapped object. In order for
+            the message to be appended to the docstring, `update_docstring`
+            must be True. Default is 80.
+
+        kind : str or None
+            The kind of object that is wrapped (e.g., "function", "class"
+            "staticmethod"). The `inspect` module automatically tries to
+            determine the value of `kind`, but `inspect` may sometimes fail
+            to identify the object appropriately, in which case, you can
+            explicitly specify the kind of object that is wrapped (which
+            will skip inspection). Default is None.
+
+        reason : str or None
+            The reason for issuing the warning. Default is None.
+
+        remove_in : str or None
+            The version that the wrapped object is planned to be removed in.
+            If specified, and the version of GTC is greater than or equal
+            to the `remove_in` value, an exception is raised when
+            @decorated() is invoked. Default is None.
+
+        stacklevel : int
+            Number of frames up the stack that issued the warning. Default is 3.
+
+        update_docstring : bool
+            Whether to append the deprecation message to the docstring of the
+            wrapped object (for rendering with Sphinx). Default is True.
+
+        Examples,
+
+            @deprecated(reason='Stop using')
+            def foo():
+
+            @deprecated('Stop using', deprecated_in='1.5', remove_in='2.0')
+            def foo():
+
+            @deprecated('Use :func:`bar` instead', action='error')
+            def foo():
+
+    """
+    def wrapper(obj):
+        message, warn_kw = _prepare_warning(obj, **kwargs)
+        message = _regex_remove_role.sub(r'\1', message)
+
+        @functools.wraps(obj)
+        def _wrapper(*a, **kw):
+            # *a and **kw are the arguments and keyword arguments
+            # that the wrapped object takes
+            _warn(message, **warn_kw)
+            return obj(*a, **kw)
+        return _wrapper
+
+    if not (args or kwargs):
+        # Handles @deprecated()
+        return deprecated
+
+    if args:
+        if len(args) > 1:
+            raise SyntaxError(
+                '@deprecated{} has too many arguments, '
+                'only the reason (as a string) is allowed'.format(args))
+
+        arg0 = args[0]
+
+        # Handles if a string is passed in as the first argument, e.g.,
+        #   @deprecated('A message')
+        #   @deprecated('A message', deprecated_in='1.5')
+        if isinstance(arg0, str):
+            return deprecated(reason=arg0, **kwargs)
+
+        if not (inspect.isfunction(arg0) or inspect.isclass(arg0)):
+            raise TypeError(
+                'Cannot use @deprecated on an object of type {!r}'.format(
+                    type(arg0).__name__))
+
+        # Handles @deprecated
+        return wrapper(arg0)
+
+    # Handles keyword arguments, e.g.,
+    #   @deprecated(reason='A message')
+    #   @deprecated(deprecated_in='1.3', remove_in='2.0')
+    def _decorated(func):
+        return wrapper(func)
+    return _decorated
+
+
+def _prepare_warning(wrapped,
+                     action=None,
+                     category=GTCDeprecationWarning,
+                     deprecated_in=None,
+                     docstring_line_width=80,
+                     kind=None,
+                     reason=None,
+                     remove_in=None,
+                     stacklevel=3,
+                     update_docstring=True):
+    """Prepare the deprecation message.
+
+    :param wrapped: A callable object that is marked as deprecated.
+
+    All keyword arguments as defined in :func:`decorated`.
+
+    :return: The warning message and the keyword argument for :func:`_warn`.
+    :rtype: tuple(str, dict)
+    """
+    if not kind:
+        if inspect.isfunction(wrapped):
+            if PY2:
+                args = inspect.getargspec(wrapped).args
+            else:
+                args = inspect.getfullargspec(wrapped).args
+
+            if args and args[0] == 'self':
+                kind = 'method'
+            elif args and args[0] == 'cls':
+                kind = 'classmethod'
+            else:  # Could be a function or staticmethod, assume function
+                kind = 'function'
+        elif inspect.isclass(wrapped):
+            kind = 'class'
+        else:
+            kind = 'callable object'
+
+    # Builds the deprecation message
+    msg = ['The {} `{}` is deprecated'.format(kind, wrapped.__name__)]
+    if deprecated_in:
+        msg.append(' since version {}'.format(deprecated_in))
+    if remove_in:
+        msg.append(' and is planned for removal in version {}'.format(remove_in))
+    msg.append('. ')
+    if reason:
+        msg.append(reason)
+
+    message = ''.join(msg).rstrip()
+
+    if update_docstring:
+        wrapped.__doc__ = _append_sphinx_directive(
+            wrapped.__doc__,
+            message,
+            docstring_line_width=docstring_line_width,
+        )
+
+    if _running_tests and (
+            remove_in and
+            tuple(map(int, version.split('.')[:3])) >=
+            tuple(map(int, remove_in.split('.')))):
+        raise RuntimeError(
+            'Dear GTC developer, you are still using a {} that '
+            'should be removed:\n{}'.format(kind, message)
+        )
+
+    warn_kw = {'action': action, 'category': category, 'stacklevel': stacklevel}
+    return message, warn_kw
+
+
+def _append_sphinx_directive(docstring,
+                             message,
+                             docstring_line_width=80):
+    """Append the ".. warning::" Sphinx directive to a docstring.
+
+    :param docstring: The docstring of the wrapped object.
+    :type docstring: str or None
+
+    :param message: The warning message.
+    :type message: str
+
+    All other keyword arguments are defined in :func:`decorated`.
+
+    :return: The docstring with the Sphinx directive appended.
+    :rtype: str
+    """
+    # A docstring can be None
+    docstring = docstring or ''
+
+    # The docstring may either start on the same line as the triple
+    # quotes or on the next line. Ensure that the dedent() function
+    # handles either case correctly.
+    lines = docstring.rstrip().splitlines(True) or ['']
+    docstring = lines[0] + textwrap.dedent(''.join(lines[1:]))
+
+    indent = '   '
+    width = max(1, docstring_line_width - len(indent))
+
+    # there must be at least one empty line before the Sphinx directive
+    directive = ['\n\n.. warning::']
+    for line in message.splitlines():
+        if line:
+            directive.append(
+                textwrap.fill(
+                    line,
+                    width=width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                ))
+        else:
+            directive.append('')
+
+    # an empty line should follow the Sphinx directive
+    directive.append('')
+
+    return docstring + '\n'.join(directive)
+
+
+def _warn(message,
+          action=None,
+          category=GTCDeprecationWarning,
+          stacklevel=3):
+    """Issue a warning, or maybe ignore it or raise an exception.
+
+    :param message: The warning message.
+    :type message: str
+
+    All other keyword arguments are defined in :func:`decorated`.
+    """
+    if action:
+        with warnings.catch_warnings():
+            warnings.simplefilter(action, category)
+            warnings.warn(message, category=category, stacklevel=stacklevel)
+    else:
+        warnings.warn(message, category=category, stacklevel=stacklevel)

--- a/GTC/deprecated.py
+++ b/GTC/deprecated.py
@@ -94,6 +94,13 @@ def deprecated(*args, **kwargs):
             kind of object that is wrapped (which will skip inspection).
             Default is None.
 
+        prefix : str or None
+            The text to insert before the deprecation message that is
+            constructed from other keyword arguments. For example, you may
+            want to insert the newline character so that when warnings.warn()
+            is called, the deprecation message appears on a new line.
+            Default is None.
+
         reason : str or None
             The reason for issuing the warning. Default is None.
 
@@ -175,6 +182,7 @@ def _prepare_warning(wrapped,
                      deprecated_in=None,
                      docstring_line_width=80,
                      kind=None,
+                     prefix=None,
                      reason=None,
                      remove_in=None,
                      stacklevel=3,
@@ -207,7 +215,10 @@ def _prepare_warning(wrapped,
             kind = 'callable object'
 
     # Builds the deprecation message
-    msg = ['The {} `{}` is deprecated'.format(kind, wrapped.__name__)]
+    msg = []
+    if prefix:
+        msg.append(prefix)
+    msg.append('The {} `{}` is deprecated'.format(kind, wrapped.__name__))
     if deprecated_in:
         msg.append(' since version {}'.format(deprecated_in))
     if remove_in:

--- a/GTC/deprecated.py
+++ b/GTC/deprecated.py
@@ -318,8 +318,9 @@ def _warn(message,
     # application's global context is not modified. In the case of "once", this
     # has the effect of restoring the internal call counter, so a warning message
     # is issued every time the line issuing the warning is called. Therefore,
-    # for action="once" we treat it equivalent to not specifying the action.
-    if action and action != 'once':
+    # for action="once" (and "default") we treat it equivalent to not specifying
+    # the action.
+    if action and action not in ('once', 'default'):
         with warnings.catch_warnings():
             warnings.simplefilter(action, category)
             warnings.warn(message, category=category, stacklevel=stacklevel)

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,13 @@
 """
 Injects GTC in to the doctest namespace for pytest.
 """
+import os
 import sys
 
 import pytest
+
+# This environment variable must be defined before GTC is imported
+os.environ['GTC_RUNNING_TESTS'] = 'true'
 
 from GTC import *
 

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 import warnings
 
@@ -27,7 +28,8 @@ class TestDeprecated(unittest.TestCase):
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
             self.assertEqual(str(warn[0].message), 'The function `foo` is deprecated.')
-            self.assertEqual(warn[0].lineno, 26)  # where foo() is actually called
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-4)  # where foo() is actually called
 
     def test_nested_function(self):
         @deprecated
@@ -47,7 +49,8 @@ class TestDeprecated(unittest.TestCase):
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
             self.assertEqual(str(warn[0].message), 'The function `foo` is deprecated.')
-            self.assertEqual(warn[0].lineno, 39)  # where foo() is called in bar()
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-11)  # where foo() is called in bar()
 
     def test_class_no_args_no_kwargs(self):
 
@@ -70,7 +73,8 @@ class TestDeprecated(unittest.TestCase):
             self.assertEqual(len(warn), 1)  # f.bar() does not issue a warning
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
             self.assertEqual(str(warn[0].message), 'The class `Foo` is deprecated.')
-            self.assertEqual(warn[0].lineno, 68)  # where Foo() is actually instantiated
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-5)  # where Foo() is actually instantiated
 
             Foo()
             self.assertEqual(len(warn), 2)
@@ -101,7 +105,8 @@ class TestDeprecated(unittest.TestCase):
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
             self.assertEqual(str(warn[0].message), 'The method `bar` is deprecated.')
-            self.assertEqual(warn[0].lineno, 100)  # where f.bar() is actually called
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-4)  # where f.bar() is actually called
 
             Foo()
             self.assertEqual(len(warn), 1)
@@ -255,8 +260,9 @@ class TestDeprecated(unittest.TestCase):
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter('always')
             fcn()
-            # Not sure what lineno will be, but it won't be 247
-            self.assertNotEqual(warn[0].lineno, 247)
+            # Not sure what lineno will be, but it won't be where fcn() is called
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertNotEqual(warn[0].lineno, f_lineno-1)
 
     def test_docstring_line_width(self):
         @deprecated(deprecated_in='1.5', docstring_line_width=20)
@@ -311,7 +317,8 @@ class TestDeprecated(unittest.TestCase):
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
             self.assertEqual(str(warn[0].message), 'The function `bar` is deprecated.')
-            self.assertEqual(warn[0].lineno, 310)  # where f.bar() is actually called
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-4)  # where f.bar() is actually called
 
     def test_static_method_2(self):
         # The inspect module cannot differential between a function
@@ -340,7 +347,8 @@ class TestDeprecated(unittest.TestCase):
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
             self.assertEqual(str(warn[0].message), 'The staticmethod `bar` is deprecated.')
-            self.assertEqual(warn[0].lineno, 339)  # where f.bar() is actually called
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-4)  # where f.bar() is actually called
 
     def test_class_method(self):
         # The inspect module cannot differential between a function
@@ -378,7 +386,8 @@ class TestDeprecated(unittest.TestCase):
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
             self.assertEqual(str(warn[0].message), 'The classmethod `bar` is deprecated.')
-            self.assertEqual(warn[0].lineno, 377)  # where f.bar() is actually called
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-4)  # where f.bar() is actually called
             self.assertEqual(f2.x, 8)
 
     def test_update_docstring(self):
@@ -406,7 +415,8 @@ class TestDeprecated(unittest.TestCase):
             self.assertEqual(len(warn), 1)  # f.bar() does not issue a warning
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
             self.assertEqual(str(warn[0].message), 'The class `Foo` is deprecated.')
-            self.assertEqual(warn[0].lineno, 402)  # where Foo() is actually instantiated
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-7)  # where Foo() is actually instantiated
 
     def test_multiple(self):
         @deprecated
@@ -537,7 +547,8 @@ class TestDeprecated(unittest.TestCase):
                 '            Same indent\n'
                 '                Indent 2'
             )
-            self.assertEqual(warn[0].lineno, 527)  # where Foo().bar() is actually called
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-13)  # where Foo().bar() is actually called
 
     def test_remove_sphinx_role(self):
 
@@ -568,7 +579,8 @@ class TestDeprecated(unittest.TestCase):
                 'The class `Foo` is deprecated. Do not use anymore, use `.dump_xml`, '
                 '`~GTC.persistence.dump_json` or `Archive.dump` instead'
             )
-            self.assertEqual(warn[0].lineno, 563)  # where Foo() is actually instantiated
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-8)  # where Foo() is actually instantiated
 
     def test_prefix(self):
 
@@ -594,7 +606,8 @@ class TestDeprecated(unittest.TestCase):
                 str(warn[0].message),
                 'My message. The function `foo` is deprecated.'
             )
-            self.assertEqual(warn[0].lineno, 590)  # where foo() is actually called
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-7)  # where foo() is actually called
 
     def test_prefix_newline(self):
 
@@ -621,7 +634,8 @@ class TestDeprecated(unittest.TestCase):
                 str(warn[0].message),
                 '\nThe function `foo` is deprecated.'
             )
-            self.assertEqual(warn[0].lineno, 617)  # where foo() is actually called
+            f_lineno = inspect.currentframe().f_lineno
+            self.assertEqual(warn[0].lineno, f_lineno-7)  # where foo() is actually called
 
     def test_docstring_1(self):
         s = _append_sphinx_directive(None, 'Message')

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -261,6 +261,28 @@ class TestDeprecated(unittest.TestCase):
                 self.assertEqual(
                     str(w.message), 'The function `foo` is deprecated.')
 
+    def test_action_default(self):
+        # default: first occurrence of matching warnings for each location
+        # (module + line number) where the warning is issued
+        @deprecated(action='default')
+        def foo(): return
+
+        def bar(): return foo()
+
+        with warnings.catch_warnings(record=True) as warn:
+            for _ in range(10):
+                foo()
+            self.assertEqual(len(warn), 1)
+
+            for _ in range(10):
+                foo()
+                bar()
+            self.assertEqual(len(warn), 3)
+
+            for w in warn:
+                self.assertEqual(
+                    str(w.message), 'The function `foo` is deprecated.')
+
     def test_category(self):
         @deprecated(category=RuntimeWarning)
         def fcn(): return

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -570,6 +570,59 @@ class TestDeprecated(unittest.TestCase):
             )
             self.assertEqual(warn[0].lineno, 563)  # where Foo() is actually instantiated
 
+    def test_prefix(self):
+
+        @deprecated(prefix='My message. ')
+        def foo(*args, **kwargs):
+            """Docstring for function foo."""
+            return args, kwargs
+
+        self.assertEqual(foo.__name__, 'foo')
+        self.assertEqual(
+            foo.__doc__,
+            'Docstring for function foo.\n\n'
+            '.. warning::\n'
+            '   My message. The function `foo` is deprecated.\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertEqual(foo(-1, 0, 1, a='a'), ((-1, 0, 1), {'a': 'a'}))
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(
+                str(warn[0].message),
+                'My message. The function `foo` is deprecated.'
+            )
+            self.assertEqual(warn[0].lineno, 590)  # where foo() is actually called
+
+    def test_prefix_newline(self):
+
+        @deprecated(prefix='\n')
+        def foo(*args, **kwargs):
+            """Docstring for function foo."""
+            return args, kwargs
+
+        self.assertEqual(foo.__name__, 'foo')
+        self.assertEqual(
+            foo.__doc__,
+            'Docstring for function foo.\n\n'
+            '.. warning::\n'
+            '\n'
+            '   The function `foo` is deprecated.\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertEqual(foo(-1, 0, 1, a='a'), ((-1, 0, 1), {'a': 'a'}))
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(
+                str(warn[0].message),
+                '\nThe function `foo` is deprecated.'
+            )
+            self.assertEqual(warn[0].lineno, 617)  # where foo() is actually called
+
     def test_docstring_1(self):
         s = _append_sphinx_directive(None, 'Message')
         self.assertEqual(

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -207,6 +207,16 @@ class TestDeprecated(unittest.TestCase):
                 str(warn[0].message),
                 'The function `function` is deprecated.'
             )
+            # the warning is issued on the same line in the same module,
+            # so it is only issued once, so action="once" is equivalent to
+            # action="default" (or not specifying the action parameter at all)
+            self.assertEqual(len(warn), 1)
+
+            # these will issue 3 more warnings, since they occur on different lines
+            function()
+            function()
+            function()
+            self.assertEqual(len(warn), 4)
 
     def test_action_ignore(self):
         @deprecated(action='ignore')

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -283,6 +283,11 @@ class TestDeprecated(unittest.TestCase):
                 self.assertEqual(
                     str(w.message), 'The function `foo` is deprecated.')
 
+    def test_action_module(self):
+        with self.assertRaises(ValueError):
+            @deprecated(action='module')
+            def foo(): return
+
     def test_category(self):
         @deprecated(category=RuntimeWarning)
         def fcn(): return

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -1,0 +1,688 @@
+import unittest
+import warnings
+
+from GTC.deprecated import GTCDeprecationWarning
+from GTC.deprecated import _append_sphinx_directive
+from GTC.deprecated import deprecated
+
+
+class TestDeprecated(unittest.TestCase):
+
+    def test_function_no_args_no_kwargs(self):
+
+        @deprecated
+        def foo():
+            """Docstring for foo"""
+            return 'Called foo'
+
+        self.assertEqual(foo.__name__, 'foo')
+        self.assertEqual(
+            foo.__doc__,
+            'Docstring for foo\n\n.. warning::\n   The function `foo` is deprecated.\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertEqual(foo(), 'Called foo')
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(str(warn[0].message), 'The function `foo` is deprecated.')
+            self.assertEqual(warn[0].lineno, 26)  # where foo() is actually called
+
+    def test_nested_function(self):
+        @deprecated
+        def foo():
+            """Docstring for foo"""
+            return 'Called foo'
+
+        def bar():
+            return foo()
+
+        def baz():
+            return bar()
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertEqual(baz(), 'Called foo')
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(str(warn[0].message), 'The function `foo` is deprecated.')
+            self.assertEqual(warn[0].lineno, 39)  # where foo() is called in bar()
+
+    def test_class_no_args_no_kwargs(self):
+
+        @deprecated
+        class Foo:
+            """Docstring for class foo"""
+            def __init__(self): pass
+            def bar(self): pass
+
+        self.assertEqual(Foo.__name__, 'Foo')
+        self.assertEqual(
+            Foo.__doc__,
+            'Docstring for class foo\n\n.. warning::\n   The class `Foo` is deprecated.\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            f = Foo()
+            f.bar()
+            self.assertEqual(len(warn), 1)  # f.bar() does not issue a warning
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(str(warn[0].message), 'The class `Foo` is deprecated.')
+            self.assertEqual(warn[0].lineno, 68)  # where Foo() is actually instantiated
+
+            Foo()
+            self.assertEqual(len(warn), 2)
+
+    def test_method_no_args_no_kwargs(self):
+
+        class Foo:
+            """Docstring for class foo"""
+            def __init__(self): pass
+
+            @deprecated()
+            def bar(self):
+                """Docstring for method bar"""
+                pass
+
+        self.assertEqual(Foo.bar.__name__, 'bar')
+        self.assertEqual(
+            Foo.bar.__doc__,
+            'Docstring for method bar\n\n.. warning::\n   The method `bar` is deprecated.\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            f = Foo()
+            self.assertEqual(len(warn), 0)
+
+            f.bar()
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(str(warn[0].message), 'The method `bar` is deprecated.')
+            self.assertEqual(warn[0].lineno, 100)  # where f.bar() is actually called
+
+            Foo()
+            self.assertEqual(len(warn), 1)
+
+    def test_reason_as_arg(self):
+        @deprecated('Do not use anymore')
+        def function(x=0):
+            return x
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertEqual(function(), 0)
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(
+                str(warn[0].message),
+                'The function `function` is deprecated. Do not use anymore'
+            )
+            self.assertEqual(function(1), 1)
+            self.assertEqual(len(warn), 2)
+            self.assertEqual(function(x=21), 21)
+            self.assertEqual(len(warn), 3)
+
+    def test_reason_as_kwarg(self):
+        @deprecated(reason='Do not use anymore')
+        def function(x=0):
+            return x
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertEqual(function(), 0)
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(
+                str(warn[0].message),
+                'The function `function` is deprecated. Do not use anymore'
+            )
+            self.assertEqual(function(1), 1)
+            self.assertEqual(len(warn), 2)
+            self.assertEqual(function(x=21), 21)
+            self.assertEqual(len(warn), 3)
+
+    def test_deprecated_in(self):
+        @deprecated('\nMessage\t\n', deprecated_in='1.2')
+        def function(x, y=0):
+            return x+y
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertEqual(function(0), 0)
+            self.assertEqual(len(warn), 1)
+            self.assertEqual(function(1, y=5), 6)
+            self.assertEqual(len(warn), 2)
+            self.assertEqual(function(x=21, y=-21), 0)
+            self.assertEqual(len(warn), 3)
+            for i in range(3):
+                self.assertTrue(issubclass(warn[i].category, GTCDeprecationWarning))
+                self.assertEqual(
+                    str(warn[1].message),
+                    'The function `function` is deprecated since version 1.2. \nMessage'
+                )
+
+    def test_deprecated_in_remove_in(self):
+        @deprecated('Message to\nshow', deprecated_in='1.2', remove_in='9999.9999')
+        def function():
+            return
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertIsNone(function())
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(
+                str(warn[0].message),
+                'The function `function` is deprecated since version 1.2 and is '
+                'planned for removal in version 9999.9999. Message to\nshow'
+            )
+
+    def test_too_many_args(self):
+        with self.assertRaises(SyntaxError) as err:
+            @deprecated('A', '1.5')
+            def function(): pass
+        self.assertEqual(
+            str(err.exception),
+            "@deprecated('A', '1.5') has too many arguments, "
+            "only the reason (as a string) is allowed"
+        )
+
+    def test_arg_wrong_type(self):
+        with self.assertRaises(TypeError) as err:
+            @deprecated(1.2)
+            def function(): pass
+        self.assertEqual(
+            str(err.exception),
+            "Cannot use @deprecated on an object of type 'float'"
+        )
+
+    def test_action_once(self):
+        @deprecated(action='once')
+        def function(): return
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            for _ in range(10):
+                function()
+            self.assertEqual(
+                str(warn[0].message),
+                'The function `function` is deprecated.'
+            )
+
+    def test_action_ignore(self):
+        @deprecated(action='ignore')
+        def function(): return
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            for _ in range(10):
+                function()
+            self.assertEqual(len(warn), 0)
+
+    def test_action_error(self):
+        @deprecated(action='error')
+        def stop_using(): return
+
+        with self.assertRaises(GTCDeprecationWarning) as err:
+            stop_using()
+
+        self.assertEqual(
+            str(err.exception),
+            "The function `stop_using` is deprecated."
+        )
+
+    def test_category(self):
+        @deprecated(category=RuntimeWarning)
+        def fcn(): return
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertIsNone(fcn())
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, RuntimeWarning))
+            self.assertEqual(
+                str(warn[0].message),
+                'The function `fcn` is deprecated.'
+            )
+
+    def test_stacklevel(self):
+        @deprecated(stacklevel=2)
+        def fcn(): return
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            fcn()
+            # Not sure what lineno will be, but it won't be 247
+            self.assertNotEqual(warn[0].lineno, 247)
+
+    def test_docstring_line_width(self):
+        @deprecated(deprecated_in='1.5', docstring_line_width=20)
+        def fcn():
+            """
+            Docstring.
+            """
+            return
+
+        self.assertEqual(
+            fcn.__doc__,
+            '\nDocstring.\n\n.. warning::\n   The function\n   `fcn` is'
+            '\n   deprecated\n   since version\n   1.5.\n'
+        )
+
+    def test_remove_in_raises(self):
+        # This must raise an exception because GTC version > remove_in value.
+        # The `stop_using` function does not even need to be called.
+        # Decorating it, is sufficient.
+        # This does require that GTC.deprecated._running_tests = True
+        # which should be True when the tests are run.
+        with self.assertRaises(RuntimeError) as err:
+            @deprecated(remove_in='0.1')
+            def stop_using(): return
+
+        self.assertTrue(str(err.exception).startswith('Dear GTC developer'))
+
+    def test_static_method_1(self):
+        # The inspect module cannot differential between a function
+        # and a staticmethod, the default that chosen is a function
+
+        class Foo:
+            def __init__(self): pass
+
+            @staticmethod
+            @deprecated
+            def bar(x=0):
+                """Docstring."""
+                return x
+
+        self.assertEqual(Foo.bar.__name__, 'bar')
+        self.assertEqual(
+            Foo.bar.__doc__,
+            'Docstring.\n\n.. warning::\n   The function `bar` is deprecated.\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            f = Foo()
+            self.assertEqual(len(warn), 0)
+            self.assertEqual(f.bar(8), 8)
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(str(warn[0].message), 'The function `bar` is deprecated.')
+            self.assertEqual(warn[0].lineno, 310)  # where f.bar() is actually called
+
+    def test_static_method_2(self):
+        # The inspect module cannot differential between a function
+        # and a staticmethod, explicitly define the "kind"
+
+        class Foo:
+            def __init__(self): pass
+
+            @staticmethod
+            @deprecated(kind='staticmethod')
+            def bar(x=0):
+                """Docstring."""
+                return x
+
+        self.assertEqual(Foo.bar.__name__, 'bar')
+        self.assertEqual(
+            Foo.bar.__doc__,
+            'Docstring.\n\n.. warning::\n   The staticmethod `bar` is deprecated.\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            f = Foo()
+            self.assertEqual(len(warn), 0)
+            self.assertEqual(f.bar(8), 8)
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(str(warn[0].message), 'The staticmethod `bar` is deprecated.')
+            self.assertEqual(warn[0].lineno, 339)  # where f.bar() is actually called
+
+    def test_class_method(self):
+        # The inspect module cannot differential between a function
+        # and a staticmethod, the default that chosen is a function
+
+        class Foo:
+            def __init__(self, x=0):
+                self.x = x
+
+            @classmethod
+            @deprecated
+            def bar(cls, x):
+                """Docstring.
+
+                :param x: The x value.
+                :type x: int
+                """
+                return Foo(x=x)
+
+        self.assertEqual(Foo.bar.__name__, 'bar')
+        self.assertEqual(
+            Foo.bar.__doc__,
+            'Docstring.\n\n'
+            ':param x: The x value.\n'
+            ':type x: int\n\n'
+            '.. warning::\n'
+            '   The classmethod `bar` is deprecated.\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            f = Foo()
+            self.assertEqual(len(warn), 0)
+            f2 = f.bar(8)
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(str(warn[0].message), 'The classmethod `bar` is deprecated.')
+            self.assertEqual(warn[0].lineno, 377)  # where f.bar() is actually called
+            self.assertEqual(f2.x, 8)
+
+    def test_update_docstring(self):
+
+        @deprecated(update_docstring=False)
+        class Foo:
+            """
+            Docstring for class foo
+            """
+            def __init__(self): pass
+            def bar(self): pass
+
+        self.assertEqual(Foo.__name__, 'Foo')
+        self.assertEqual(
+            Foo.__doc__,
+            '\n            Docstring for class foo\n            '
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            f = Foo()
+            f.bar()
+            f.bar()
+            f.bar()
+            self.assertEqual(len(warn), 1)  # f.bar() does not issue a warning
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(str(warn[0].message), 'The class `Foo` is deprecated.')
+            self.assertEqual(warn[0].lineno, 402)  # where Foo() is actually instantiated
+
+    def test_multiple(self):
+        @deprecated
+        def foo():
+            """foo"""
+            return 'foo'
+
+        @deprecated('Bar', deprecated_in='1.1')
+        def bar():
+            """bar"""
+            return 'bar'
+
+        @deprecated(reason='Baz', deprecated_in='0.8', remove_in='9999.9999')
+        def baz():
+            """baz"""
+            return 'baz'
+
+        def hello():
+            return 'world'
+
+        self.assertEqual(foo.__name__, 'foo')
+        self.assertEqual(
+            foo.__doc__,
+            'foo\n\n'
+            '.. warning::\n'
+            '   The function `foo` is deprecated.\n'
+        )
+
+        self.assertEqual(bar.__name__, 'bar')
+        self.assertEqual(
+            bar.__doc__,
+            'bar\n\n.. warning::\n   The function `bar` is deprecated '
+            'since version 1.1. Bar\n'
+        )
+
+        self.assertEqual(baz.__name__, 'baz')
+        self.assertEqual(
+            baz.__doc__,
+            'baz\n\n.. warning::\n   The function `baz` is deprecated since '
+            'version 0.8 and is planned for\n   removal in version 9999.9999. Baz\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertEqual(foo(), 'foo')
+            self.assertEqual(hello(), 'world')
+            self.assertEqual(foo(), 'foo')
+            self.assertEqual(bar(), 'bar')
+            self.assertEqual(foo(), 'foo')
+            self.assertEqual(baz(), 'baz')
+            self.assertEqual(baz(), 'baz')
+            self.assertEqual(hello(), 'world')
+
+            self.assertEqual(len(warn), 6)
+            self.assertEqual(
+                str(warn[0].message),
+                'The function `foo` is deprecated.'
+            )
+            self.assertEqual(
+                str(warn[1].message),
+                'The function `foo` is deprecated.'
+            )
+            self.assertEqual(
+                str(warn[2].message),
+                'The function `bar` is deprecated since version 1.1. Bar'
+            )
+            self.assertEqual(
+                str(warn[3].message),
+                'The function `foo` is deprecated.'
+            )
+            self.assertEqual(
+                str(warn[4].message),
+                'The function `baz` is deprecated since version 0.8 and '
+                'is planned for removal in version 9999.9999. Baz')
+            self.assertEqual(
+                str(warn[5].message),
+                'The function `baz` is deprecated since version 0.8 and '
+                'is planned for removal in version 9999.9999. Baz')
+
+    def test_reason_with_indents(self):
+
+        class Foo:
+            def __init__(self): pass
+
+            @deprecated("""Do not use this anymore.
+
+        Paragraph 1
+            Indent 1
+
+        Paragraph 2
+
+            Indent 1
+            Same indent
+                Indent 2            
+            """)
+            def bar(self):
+                """
+                Docstring for bar.
+                """
+                return 'bar'
+
+        self.assertEqual(Foo.bar.__name__, 'bar')
+        self.assertEqual(
+            Foo.bar.__doc__,
+            '\nDocstring for bar.\n\n'
+            '.. warning::\n'
+            '   The method `bar` is deprecated. Do not use this anymore.\n\n'
+            '           Paragraph 1\n'
+            '               Indent 1\n\n'
+            '           Paragraph 2\n\n'
+            '               Indent 1\n'
+            '               Same indent\n'
+            '                   Indent 2\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self.assertEqual(Foo().bar(), 'bar')
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(
+                str(warn[0].message),
+                'The method `bar` is deprecated. Do not use this anymore.\n\n'
+                '        Paragraph 1\n'
+                '            Indent 1\n\n'
+                '        Paragraph 2\n\n'
+                '            Indent 1\n'
+                '            Same indent\n'
+                '                Indent 2'
+            )
+            self.assertEqual(warn[0].lineno, 527)  # where Foo().bar() is actually called
+
+    def test_remove_sphinx_role(self):
+
+        @deprecated('Do not use anymore, use :func:`.dump_xml`, '
+                    ':py:func:`~GTC.persistence.dump_json` or '
+                    ':meth:`Archive.dump` instead')
+        class Foo:
+            """Docstring for class foo."""
+            def __init__(self): pass
+            def bar(self): pass
+
+        self.assertEqual(Foo.__name__, 'Foo')
+        self.assertEqual(
+            Foo.__doc__,
+            'Docstring for class foo.\n\n'
+            '.. warning::\n'
+            '   The class `Foo` is deprecated. Do not use anymore, use :func:`.dump_xml`,\n'
+            '   :py:func:`~GTC.persistence.dump_json` or :meth:`Archive.dump` instead\n'
+        )
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            Foo()
+            self.assertEqual(len(warn), 1)
+            self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
+            self.assertEqual(
+                str(warn[0].message),
+                'The class `Foo` is deprecated. Do not use anymore, use `.dump_xml`, '
+                '`~GTC.persistence.dump_json` or `Archive.dump` instead'
+            )
+            self.assertEqual(warn[0].lineno, 563)  # where Foo() is actually instantiated
+
+    def test_docstring_1(self):
+        s = _append_sphinx_directive(None, 'Message')
+        self.assertEqual(
+            s,
+            '\n\n.. warning::\n   Message\n'
+        )
+
+    def test_docstring_2(self):
+        s = _append_sphinx_directive(None, 'Message', docstring_line_width=4)
+        self.assertEqual(
+            s,
+            '\n\n.. warning::\n   M\n   e\n   s\n   s\n   a\n   g\n   e\n'
+        )
+
+    def test_docstring_3(self):
+        s = _append_sphinx_directive(' \n\n \n \t', 'This is now deprecated')
+        self.assertEqual(
+            s,
+            '\n\n.. warning::\n   This is now deprecated\n'
+        )
+
+    def test_docstring_4(self):
+        s = _append_sphinx_directive('Hello', 'This is now deprecated')
+        self.assertEqual(
+            s,
+            'Hello\n\n.. warning::\n   This is now deprecated\n'
+        )
+
+    def test_docstring_5(self):
+        docstring = """
+            Hello world
+            """
+
+        s = _append_sphinx_directive(docstring, 'This is now deprecated')
+        self.assertEqual(
+            s,
+            '\nHello world\n\n.. warning::\n   This is now deprecated\n'
+        )
+
+    def test_docstring_6(self):
+        docstring = """Hello world
+
+                    A big indentation.
+                    Is occurring.
+
+                    :param x: The x value.
+                        Must be > 0.
+
+
+                    """
+
+        s = _append_sphinx_directive(
+            docstring, 'This is now deprecated', docstring_line_width=13)
+
+        self.assertEqual(
+            s,
+            'Hello world\n\nA big indentation.\nIs occurring.\n\n'
+            ':param x: The x value.\n    Must be > 0.\n\n.. warning::'
+            '\n   This is\n   now dep\n   recated\n'
+        )
+
+    def test_docstring_7(self):
+        docstring = """
+                    Hello world
+
+                    A big indentation.
+                    Is occurring.
+
+                    :param x: The x value.
+                        Must be > 0.
+                    """
+
+        s = _append_sphinx_directive(
+            docstring, 'This is now deprecated', docstring_line_width=13)
+
+        self.assertEqual(
+            s,
+            '\nHello world\n\nA big indentation.\nIs occurring.\n\n'
+            ':param x: The x value.\n    Must be > 0.\n\n.. warning::'
+            '\n   This is\n   now dep\n   recated\n'
+        )
+
+    def test_docstring_8(self):
+        docstring = """
+\tHello world
+\t
+\tThis docstring uses tabs.
+"""
+
+        s = _append_sphinx_directive(
+            docstring, 'This is now deprecated')
+
+        self.assertEqual(
+            s,
+            '\nHello world\n\nThis docstring uses tabs.'
+            '\n\n.. warning::\n   This is now deprecated\n'
+        )
+
+    def test_docstring_9(self):
+        docstring = """Hello world
+\t
+\tThis docstring uses tabs.
+"""
+
+        s = _append_sphinx_directive(
+            docstring, 'This is now deprecated')
+
+        self.assertEqual(
+            s,
+            'Hello world\n\nThis docstring uses tabs.'
+            '\n\n.. warning::\n   This is now deprecated\n'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -239,6 +239,28 @@ class TestDeprecated(unittest.TestCase):
             "The function `stop_using` is deprecated."
         )
 
+    def test_action_always(self):
+        @deprecated(action='always')
+        def foo(): return
+
+        def bar(): return
+
+        with warnings.catch_warnings(record=True) as warn:
+            for _ in range(10):
+                foo()
+                bar()
+            self.assertEqual(len(warn), 10)
+            foo()
+            bar()
+            bar()
+            foo()
+            foo()
+            bar()
+            self.assertEqual(len(warn), 13)
+            for w in warn:
+                self.assertEqual(
+                    str(w.message), 'The function `foo` is deprecated.')
+
     def test_category(self):
         @deprecated(category=RuntimeWarning)
         def fcn(): return

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -23,7 +23,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertEqual(foo(), 'Called foo')
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
@@ -44,13 +43,12 @@ class TestDeprecated(unittest.TestCase):
             return bar()
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertEqual(baz(), 'Called foo')
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
             self.assertEqual(str(warn[0].message), 'The function `foo` is deprecated.')
             f_lineno = inspect.currentframe().f_lineno
-            self.assertEqual(warn[0].lineno, f_lineno-11)  # where foo() is called in bar()
+            self.assertEqual(warn[0].lineno, f_lineno-10)  # where foo() is called in bar()
 
     def test_class_no_args_no_kwargs(self):
 
@@ -67,7 +65,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             f = Foo()
             f.bar()
             self.assertEqual(len(warn), 1)  # f.bar() does not issue a warning
@@ -97,7 +94,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             f = Foo()
             self.assertEqual(len(warn), 0)
 
@@ -117,7 +113,6 @@ class TestDeprecated(unittest.TestCase):
             return x
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertEqual(function(), 0)
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
@@ -136,7 +131,6 @@ class TestDeprecated(unittest.TestCase):
             return x
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertEqual(function(), 0)
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
@@ -155,7 +149,6 @@ class TestDeprecated(unittest.TestCase):
             return x+y
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertEqual(function(0), 0)
             self.assertEqual(len(warn), 1)
             self.assertEqual(function(1, y=5), 6)
@@ -175,7 +168,6 @@ class TestDeprecated(unittest.TestCase):
             return
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertIsNone(function())
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
@@ -209,7 +201,6 @@ class TestDeprecated(unittest.TestCase):
         def function(): return
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             for _ in range(10):
                 function()
             self.assertEqual(
@@ -222,7 +213,6 @@ class TestDeprecated(unittest.TestCase):
         def function(): return
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             for _ in range(10):
                 function()
             self.assertEqual(len(warn), 0)
@@ -244,7 +234,6 @@ class TestDeprecated(unittest.TestCase):
         def fcn(): return
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertIsNone(fcn())
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, RuntimeWarning))
@@ -258,7 +247,6 @@ class TestDeprecated(unittest.TestCase):
         def fcn(): return
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             fcn()
             # Not sure what lineno will be, but it won't be where fcn() is called
             f_lineno = inspect.currentframe().f_lineno
@@ -310,7 +298,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             f = Foo()
             self.assertEqual(len(warn), 0)
             self.assertEqual(f.bar(8), 8)
@@ -340,7 +327,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             f = Foo()
             self.assertEqual(len(warn), 0)
             self.assertEqual(f.bar(8), 8)
@@ -379,7 +365,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             f = Foo()
             self.assertEqual(len(warn), 0)
             f2 = f.bar(8)
@@ -407,7 +392,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             f = Foo()
             f.bar()
             f.bar()
@@ -460,7 +444,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertEqual(foo(), 'foo')
             self.assertEqual(hello(), 'world')
             self.assertEqual(foo(), 'foo')
@@ -533,7 +516,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertEqual(Foo().bar(), 'bar')
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
@@ -570,7 +552,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             Foo()
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
@@ -598,7 +579,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertEqual(foo(-1, 0, 1, a='a'), ((-1, 0, 1), {'a': 'a'}))
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))
@@ -626,7 +606,6 @@ class TestDeprecated(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter('always')
             self.assertEqual(foo(-1, 0, 1, a='a'), ((-1, 0, 1), {'a': 'a'}))
             self.assertEqual(len(warn), 1)
             self.assertTrue(issubclass(warn[0].category, GTCDeprecationWarning))

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -274,10 +274,10 @@ class TestDeprecated(unittest.TestCase):
 
     def test_remove_in_raises(self):
         # This must raise an exception because GTC version > remove_in value.
-        # The `stop_using` function does not even need to be called.
-        # Decorating it, is sufficient.
-        # This does require that GTC.deprecated._running_tests = True
-        # which should be True when the tests are run.
+        # The `stop_using` function does not even need to be called, simply
+        # decorating it is sufficient for the RuntimeError to be raised. This
+        # does require that GTC.deprecated._running_tests = True, which occurs
+        # when the tests are run with pytest.
         with self.assertRaises(RuntimeError) as err:
             @deprecated(remove_in='0.1')
             def stop_using(): return


### PR DESCRIPTION
Example usage,

```python
from GTC.deprecated import deprecated

@deprecated('Do not use anymore')
def foo():
    """Docstring for foo."""
    return
```
The warning is issued when `foo` is called and a deprecation warning message is automatically added to the docstring when the docs are built.