### PR TITLE
fix "SyntaxWarning: invalid escape sequence" in docstrings

### DIFF
--- a/GTC/core.py
+++ b/GTC/core.py
@@ -822,7 +822,7 @@ def log(x):
 
     .. note::
         In the complex case there is one branch cut,
-        from 0 along the negative real axis to :math:`-\infty`,
+        from 0 along the negative real axis to :math:`-\\infty`,
         continuous from above.
         
     """
@@ -846,7 +846,7 @@ def log10(x):
     .. note::
         In the complex case there is one branch cut,
         from 0 along the negative real
-        axis to :math:`-\infty`, continuous from above.
+        axis to :math:`-\\infty`, continuous from above.
         
     """
     try:
@@ -903,7 +903,7 @@ def sqrt(x):
             ...
             ZeroDivisionError: float division by zero
 
-        More generally, uncertainty in :math:`\sqrt{x}` becomes
+        More generally, uncertainty in :math:`\\sqrt{x}` becomes
         large when :math:`x` is close to zero. 
         This may be an indication that the measurement model is ill-formed or that a 
         GUM calculation of uncertainty is not appropriate.
@@ -911,7 +911,7 @@ def sqrt(x):
     .. note::
         In the complex case there is one branch cut,
         from 0 along the negative real
-        axis to :math:`-\infty`, continuous from above.
+        axis to :math:`-\\infty`, continuous from above.
         
     """
     try:
@@ -1000,9 +1000,9 @@ def asin(x):
 
     .. note::
         In the complex case there are two branch cuts: one extends
-        right, from 1 along the real axis to :math:`\infty`,
+        right, from 1 along the real axis to :math:`\\infty`,
         continuous from below; the other extends left, from -1 along
-        the real axis to :math:`-\infty`, continuous from above.
+        the real axis to :math:`-\\infty`, continuous from above.
         
     """
     try:
@@ -1037,9 +1037,9 @@ def acos(x):
         
     .. note::
         In the complex case there are two branch cuts: one extends
-        right, from 1 along the real axis to :math:`\infty`, continuous
+        right, from 1 along the real axis to :math:`\\infty`, continuous
         from below; the other extends left, from -1 along the real axis
-        to :math:`-\infty`, continuous from above.
+        to :math:`-\\infty`, continuous from above.
         
     """
     try:
@@ -1062,10 +1062,10 @@ def atan(x):
     .. note::
     
         In the complex case there are two branch cuts:
-        One extends from :math:`\mathrm{j}` along the imaginary axis to
-        :math:`\mathrm{j}\infty`, continuous from the right.
-        The other extends from :math:`-\mathrm{j}` along the imaginary
-        axis to :math:`-\mathrm{j}\infty`, continuous from the left.
+        One extends from :math:`\\mathrm{j}` along the imaginary axis to
+        :math:`\\mathrm{j}\\infty`, continuous from the right.
+        The other extends from :math:`-\\mathrm{j}` along the imaginary
+        axis to :math:`-\\mathrm{j}\\infty`, continuous from the left.
         
     """
     try:
@@ -1178,10 +1178,10 @@ def asinh(x):
     .. note::
     
         In the complex case there are two branch cuts: one extends
-        from :math:`\mathrm{j}` along the imaginary axis to
-        :math:`\mathrm{j}\infty`, continuous from the right;
-        the other extends from :math:`-\mathrm{j}` along the
-        imaginary axis to :math:`-\mathrm{j}\infty`, continuous
+        from :math:`\\mathrm{j}` along the imaginary axis to
+        :math:`\\mathrm{j}\\infty`, continuous from the right;
+        the other extends from :math:`-\\mathrm{j}` along the
+        imaginary axis to :math:`-\\mathrm{j}\\infty`, continuous
         from the left.
         
     """
@@ -1205,7 +1205,7 @@ def acosh(x):
     .. note::
         In the complex case there is one branch cut,
         extending left from 1 along the
-        real axis to :math:`-\infty`, continuous from above.
+        real axis to :math:`-\\infty`, continuous from above.
         
     """
     try:
@@ -1227,9 +1227,9 @@ def atanh(x):
 
     .. note::
         In the complex case there are two branch cuts:
-        one extends from 1 along the real axis to :math:`\infty`,
+        one extends from 1 along the real axis to :math:`\\infty`,
         continuous from below; the other extends from -1
-        along the real axis to :math:`-\infty`, continuous
+        along the real axis to :math:`-\\infty`, continuous
         from above.
         
     """

--- a/GTC/linear_algebra.py
+++ b/GTC/linear_algebra.py
@@ -107,7 +107,7 @@ def uarray(array, label=None, names=None):
 
     .. attention::
 
-       Requires numpy :math:`\geq` v1.13.0 to be installed.
+       Requires numpy :math:`\\geq` v1.13.0 to be installed.
 
     :param array: An array-like object containing :class:`int`, :class:`float`, :class:`complex`
                   :class:`~lib.UncertainReal` or :class:`~lib.UncertainComplex` elements.
@@ -255,7 +255,7 @@ def transpose(a, axes=None):
 
 #---------------------------------------------------------------------------
 def solve(a,b):
-    """Return :math:`x`, the solution of :math:`a \cdot x = b`
+    """Return :math:`x`, the solution of :math:`a \\cdot x = b`
 
     .. versionadded:: 1.1
 

--- a/GTC/reporting.py
+++ b/GTC/reporting.py
@@ -430,7 +430,7 @@ def u_bar(ucpt):
     :type ucpt: float or 4-element sequence of float
 
     If ``ucpt`` is a sequence, return the root-sum-square 
-    of the elements divided by :math:`\sqrt{2}`
+    of the elements divided by :math:`\\sqrt{2}`
 
     If ``ucpt`` is a number, return the absolute value.
 


### PR DESCRIPTION
Using invalid escape sequences in string literals has been [deprecated since Python 3.6](https://docs.python.org/dev/whatsnew/3.6.html#deprecated-python-behavior). A `DeprecationWarning` was used to issue the warning. These warnings are silent by default.

Python 3.12 [changed the `DeprecationWarning` to a `SyntaxWarning`](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes). `SyntaxWarning`s are emitted by the compiler when the code is parsed. According to the previous link:

> In a future Python version, `SyntaxError` will eventually be raised, instead of `SyntaxWarning`.

Steps to reproduce the issue:
1) checkout another branch
2) remove all .pyc files in the GTC directory
3) using Python 3.12, run `python -c "import GTC"` and the following `SyntaxWarning`'s are displayed

```console
..\GTC> python -c "import GTC"
..\GTC\core.py:843: SyntaxWarning: invalid escape sequence '\i'
  """
..\GTC\core.py:894: SyntaxWarning: invalid escape sequence '\s'
  """
..\GTC\core.py:984: SyntaxWarning: invalid escape sequence '\i'
  """
..\GTC\core.py:1021: SyntaxWarning: invalid escape sequence '\i'
  """
..\GTC\core.py:1059: SyntaxWarning: invalid escape sequence '\m'
  """
..\GTC\core.py:1175: SyntaxWarning: invalid escape sequence '\m'
  """
..\GTC\core.py:1202: SyntaxWarning: invalid escape sequence '\i'
  """
..\GTC\core.py:1225: SyntaxWarning: invalid escape sequence '\i'
  """
..\GTC\reporting.py:427: SyntaxWarning: invalid escape sequence '\s'
  """Return the magnitude of a component of uncertainty
..\GTC\linear_algebra.py:102: SyntaxWarning: invalid escape sequence '\g'
  """Create an array of uncertain numbers.
..\GTC\linear_algebra.py:258: SyntaxWarning: invalid escape sequence '\c'
  """Return :math:`x`, the solution of :math:`a \cdot x = b`
```

This fix removes all `SyntaxWarning`'s.