### PR TITLE
fix DeprecationWarning's in uarray tests

### DIFF
--- a/test/test_uncertain_array.py
+++ b/test/test_uncertain_array.py
@@ -104,10 +104,10 @@ class TestUncertainArray(unittest.TestCase):
         # make sure that a uarray of size==1 is okay
         a = uarray([ureal(1.2, 0.3, df=4.2)])
         self.assertTrue(a.dtype == object)
-        self.assertTrue(equivalent(value(a), 1.2))
-        self.assertTrue(equivalent(uncertainty(a), 0.3))
-        self.assertTrue(equivalent(variance(a), 0.09))
-        self.assertTrue(equivalent(dof(a), 4.2))
+        self.assertTrue(equivalent(value(a[0]), 1.2))
+        self.assertTrue(equivalent(uncertainty(a[0]), 0.3))
+        self.assertTrue(equivalent(variance(a[0]), 0.09))
+        self.assertTrue(equivalent(dof(a[0]), 4.2))
 
         # a 1D array
         a = uarray([ureal(1.2, 0.3, df=3.3), ureal(2.5, 0.8, df=7)])
@@ -210,17 +210,17 @@ class TestUncertainArray(unittest.TestCase):
         # make sure that a uarray of size==1 is okay
         a = uarray([ucomplex(1.2-0.5j, (1.2, 0.7, 0.7, 2.2), df=4.2)])
         self.assertTrue(a.dtype == object)
-        self.assertTrue(equivalent_complex(value(a), 1.2-0.5j))
+        self.assertTrue(equivalent_complex(value(a[0]), 1.2-0.5j))
         self.assertTrue(isinstance(uncertainty(a), UncertainArray))
-        self.assertTrue(equivalent(uncertainty(a).real, 1.0954451150103321))
-        self.assertTrue(equivalent(uncertainty(a).imag, 1.4832396974191326))
+        self.assertTrue(equivalent(uncertainty(a[0]).real, 1.0954451150103321))
+        self.assertTrue(equivalent(uncertainty(a[0]).imag, 1.4832396974191326))
         self.assertTrue(isinstance(variance(a), UncertainArray))
-        self.assertTrue(equivalent(variance(a)[0].rr, 1.2))
-        self.assertTrue(equivalent(variance(a)[0].ri, 0.7))
-        self.assertTrue(equivalent(variance(a)[0].ir, 0.7))
-        self.assertTrue(equivalent(variance(a)[0].ii, 2.2))
-        self.assertTrue(equivalent(a.r, 0.43082021842766455))
-        self.assertTrue(equivalent(dof(a), 4.2))
+        self.assertTrue(equivalent(variance(a[0]).rr, 1.2))
+        self.assertTrue(equivalent(variance(a[0]).ri, 0.7))
+        self.assertTrue(equivalent(variance(a[0]).ir, 0.7))
+        self.assertTrue(equivalent(variance(a[0]).ii, 2.2))
+        self.assertTrue(equivalent(a[0].r, 0.43082021842766455))
+        self.assertTrue(equivalent(dof(a[0]), 4.2))
 
         a = uarray([ucomplex(1.2-0.5j, (1.2, 0.7, 0.7, 2.2), df=4.2),
                     ucomplex(-0.2+1.2j, (0.9, 0.4, 0.4, 1.5), df=2.6)])
@@ -572,14 +572,14 @@ class TestUncertainArray(unittest.TestCase):
         # make sure that a uarray of size==1 is okay
         a = uarray([ureal(1.2, 0.3)])
         self.assertTrue(isinstance(a, UncertainArray))
-        self.assertTrue(equivalent(a.real.x, 1.2))
-        self.assertTrue(equivalent(a.real.u, 0.3))
+        self.assertTrue(equivalent(a[0].real.x, 1.2))
+        self.assertTrue(equivalent(a[0].real.u, 0.3))
 
         # make sure that a uarray of size==1 is okay
         a = uarray([ucomplex(1.2+3j, (0.3, 0.1))])
         self.assertTrue(isinstance(a, UncertainArray))
-        self.assertTrue(equivalent(a.real.x, 1.2))
-        self.assertTrue(equivalent(a.real.u, 0.3))
+        self.assertTrue(equivalent(a[0].real.x, 1.2))
+        self.assertTrue(equivalent(a[0].real.u, 0.3))
 
         n = len(self.xc)
         z = [x.real for x in self.x]
@@ -611,14 +611,14 @@ class TestUncertainArray(unittest.TestCase):
         # make sure that a uarray of size==1 is okay
         a = uarray([ureal(1.2, 0.3)])
         self.assertTrue(isinstance(a, UncertainArray))
-        self.assertTrue(equivalent(a.imag.x, 0.0))
-        self.assertTrue(equivalent(a.imag.u, 0.0))
+        self.assertTrue(equivalent(a[0].imag.x, 0.0))
+        self.assertTrue(equivalent(a[0].imag.u, 0.0))
 
         # make sure that a uarray of size==1 is okay
         a = uarray([ucomplex(1.2+3j, (0.3, 0.1))])
         self.assertTrue(isinstance(a, UncertainArray))
-        self.assertTrue(equivalent(a.imag.x, 3))
-        self.assertTrue(equivalent(a.imag.u, 0.1))
+        self.assertTrue(equivalent(a[0].imag.x, 3))
+        self.assertTrue(equivalent(a[0].imag.u, 0.1))
 
         n = len(self.xc)
         z = [x.imag for x in self.x]
@@ -664,8 +664,8 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(1.2, 0.3, df=4.2)])
         pos = +a
         self.assertTrue(isinstance(pos, UncertainArray))
-        self.assertTrue(equivalent(pos.x, 1.2))
-        self.assertTrue(equivalent(pos.u, 0.3))
+        self.assertTrue(equivalent(pos[0].x, 1.2))
+        self.assertTrue(equivalent(pos[0].u, 0.3))
         
         pos = +self.xa
         self.assertTrue(pos is not self.xa)
@@ -686,8 +686,8 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(1.2, 0.3, df=4.2)])
         neg = -a
         self.assertTrue(isinstance(neg, UncertainArray))
-        self.assertTrue(equivalent(neg.x, -1.2))
-        self.assertTrue(equivalent(neg.u, 0.3))
+        self.assertTrue(equivalent(neg[0].x, -1.2))
+        self.assertTrue(equivalent(neg[0].u, 0.3))
         
         neg = -self.xa
         self.assertTrue(neg is not self.xa)
@@ -709,8 +709,8 @@ class TestUncertainArray(unittest.TestCase):
         r = uarray([ureal(-0.2, 0.4, 7)])
         y = l + r
         self.assertTrue(isinstance(y, UncertainArray))
-        self.assertTrue(equivalent(y.x, 1.0))
-        self.assertTrue(equivalent(y.u, math.sqrt(0.25)))
+        self.assertTrue(equivalent(y[0].x, 1.0))
+        self.assertTrue(equivalent(y[0].u, math.sqrt(0.25)))
         
         n = len(self.x)
 
@@ -888,9 +888,9 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([nan])
         b = uarray([ureal(1, 1)])
         c = a + b
-        self.assertTrue(math.isnan(value(c)))
-        self.assertTrue(equivalent(uncertainty(c), 1))
-        self.assertTrue(math.isinf(dof(c)))
+        self.assertTrue(math.isnan(value(c[0])))
+        self.assertTrue(equivalent(uncertainty(c[0]), 1))
+        self.assertTrue(math.isinf(dof(c[0])))
 
     def test_shape_mismatch(self):
         with self.assertRaises(ValueError):
@@ -905,8 +905,8 @@ class TestUncertainArray(unittest.TestCase):
         r = uarray([ureal(-0.2, 0.4, 7)])
         y = l - r
         self.assertTrue(isinstance(y, UncertainArray))
-        self.assertTrue(equivalent(y.x, 1.4))
-        self.assertTrue(equivalent(y.u, math.sqrt(0.25)))
+        self.assertTrue(equivalent(y[0].x, 1.4))
+        self.assertTrue(equivalent(y[0].u, math.sqrt(0.25)))
 
         n = len(self.x)
 
@@ -1084,9 +1084,9 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([nan])
         b = uarray([ureal(1, 1)])
         c = a - b
-        self.assertTrue(math.isnan(value(c)))
-        self.assertTrue(equivalent(uncertainty(c), 1))
-        self.assertTrue(math.isinf(dof(c)))
+        self.assertTrue(math.isnan(value(c[0])))
+        self.assertTrue(equivalent(uncertainty(c[0]), 1))
+        self.assertTrue(math.isinf(dof(c[0])))
 
     def test_multiply(self):
         # Single element case
@@ -1094,8 +1094,8 @@ class TestUncertainArray(unittest.TestCase):
         r = uarray([ureal(-0.2, 0.4, 7)])
         y = l * r
         self.assertTrue(isinstance(y, UncertainArray))
-        self.assertTrue(equivalent(y.x, -0.24))
-        self.assertTrue(equivalent(y.u, math.sqrt((1.2*.4)**2 + (0.2*.3)**2)))
+        self.assertTrue(equivalent(y[0].x, -0.24))
+        self.assertTrue(equivalent(y[0].u, math.sqrt((1.2*.4)**2 + (0.2*.3)**2)))
 
         n = len(self.x)
 
@@ -1113,8 +1113,8 @@ class TestUncertainArray(unittest.TestCase):
         y = l / r
         self.assertTrue(isinstance(y, UncertainArray))
         q = 1.2/-0.2
-        self.assertTrue(equivalent(y.x, q))
-        self.assertTrue(equivalent(y.u, math.sqrt((q/1.2*.3)**2 + (q/-0.2*.4)**2)))
+        self.assertTrue(equivalent(y[0].x, q))
+        self.assertTrue(equivalent(y[0].u, math.sqrt((q/1.2*.3)**2 + (q/-0.2*.4)**2)))
         
         n = len(self.x)
 
@@ -1244,7 +1244,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(-0.2, 0.4, 7)])
         x = abs(a)
         self.assertTrue(isinstance(x, UncertainArray))
-        self.assertTrue(equivalent(x.x, 0.2))
+        self.assertTrue(equivalent(x.x[0], 0.2))
         
         n = len(self.x)
         z = [abs(x) for x in self.x]
@@ -1269,13 +1269,13 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(-0.2, 0.4, 7)])
         x = a.conjugate()
         self.assertTrue(isinstance(x, UncertainArray))
-        self.assertTrue(equivalent(x.x, -0.2))
+        self.assertTrue(equivalent(x[0].x, -0.2))
  
         a = uarray([ucomplex(-0.2+0.1j, 0.4, 7)])
         x = a.conjugate()
         self.assertTrue(isinstance(x, UncertainArray))
-        self.assertTrue(equivalent(x.x.real, -0.2))
-        self.assertTrue(equivalent(x.x.imag, -0.1))
+        self.assertTrue(equivalent(x[0].x.real, -0.2))
+        self.assertTrue(equivalent(x[0].x.imag, -0.1))
  
         n = len(self.xc)
         z = [x.conjugate() for x in self.x]
@@ -1307,7 +1307,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = cos(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.cos(x)))
+        self.assertTrue(equivalent(ux[0].x, math.cos(x)))
     
         n = len(self.x)
         z = [cos(x) for x in self.x]
@@ -1339,7 +1339,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = sin(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.sin(x)))
+        self.assertTrue(equivalent(ux[0].x, math.sin(x)))
     
         n = len(self.x)
         z = [sin(x) for x in self.x]
@@ -1371,7 +1371,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = tan(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.tan(x)))
+        self.assertTrue(equivalent(ux[0].x, math.tan(x)))
     
         n = len(self.x)
         z = [tan(x) for x in self.x]
@@ -1403,7 +1403,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = acos(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.acos(x)))
+        self.assertTrue(equivalent(ux[0].x, math.acos(x)))
     
         x = [ureal(0.4, 0.02), ureal(-0.3, 0.01), ureal(-0.2, 0.03), ureal(0.8, 0.03)]
         xa = uarray(x)
@@ -1455,7 +1455,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = asin(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.asin(x)))
+        self.assertTrue(equivalent(ux[0].x, math.asin(x)))
     
         x = [ureal(0.4, 0.02), ureal(-0.3, 0.01), ureal(-0.2, 0.03), ureal(0.8, 0.03)]
         xa = uarray(x)
@@ -1507,7 +1507,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = atan(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.atan(x)))
+        self.assertTrue(equivalent(ux[0].x, math.atan(x)))
     
         x = [ureal(0.4, 0.02), ureal(-0.3, 0.01), ureal(-0.2, 0.03), ureal(0.8, 0.03)]
         xa = uarray(x)
@@ -1559,11 +1559,11 @@ class TestUncertainArray(unittest.TestCase):
         y = uarray([ureal(0.3, 0.01)])
         z = atan2(x, y)
         self.assertTrue(isinstance(z, UncertainArray))
-        self.assertTrue(equivalent(z.x, math.atan2(0.4,0.3)))
+        self.assertTrue(equivalent(z[0].x, math.atan2(0.4,0.3)))
         
         z = np.arctan2(x, y)
         self.assertTrue(isinstance(z, UncertainArray))
-        self.assertTrue(equivalent(z.x, math.atan2(0.4,0.3)))
+        self.assertTrue(equivalent(z[0].x, math.atan2(0.4,0.3)))
         
         x = [ureal(0.4, 0.02), ureal(-0.3, 0.01), ureal(-0.2, 0.03), ureal(0.8, 0.03)]
         y = [ureal(0.3, 0.01), ureal(0.1, 0.06), ureal(0.16, 0.02), ureal(0.21, 0.07)]
@@ -1619,7 +1619,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = exp(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.exp(x)))
+        self.assertTrue(equivalent(ux[0].x, math.exp(x)))
     
         n = len(self.x)
         z = [exp(x) for x in self.x]
@@ -1651,7 +1651,7 @@ class TestUncertainArray(unittest.TestCase):
         y = uarray([ureal(0.3, 0.01)])
         z = x ** y
         self.assertTrue(isinstance(z, UncertainArray))
-        self.assertTrue(equivalent(z.x, 0.4 ** 0.3))
+        self.assertTrue(equivalent(z[0].x, 0.4 ** 0.3))
 
         n = len(self.x)
 
@@ -1740,7 +1740,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = log(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.log(x)))
+        self.assertTrue(equivalent(ux[0].x, math.log(x)))
     
         n = len(self.x)
         z = [log(x) for x in self.x]
@@ -1772,7 +1772,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = log10(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.log10(x)))
+        self.assertTrue(equivalent(ux[0].x, math.log10(x)))
 
         n = len(self.x)
         z = [log10(x) for x in self.x]
@@ -1804,7 +1804,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = sqrt(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.sqrt(x)))
+        self.assertTrue(equivalent(ux[0].x, math.sqrt(x)))
     
         n = len(self.x)
         z = [sqrt(x) for x in self.x]
@@ -1836,7 +1836,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x,0.4,7)])
         ux = sinh(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.sinh(x)))
+        self.assertTrue(equivalent(ux[0].x, math.sinh(x)))
     
         n = len(self.x)
         z = [sinh(x) for x in self.x]
@@ -1868,7 +1868,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = cosh(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.cosh(x)))
+        self.assertTrue(equivalent(ux[0].x, math.cosh(x)))
 
         n = len(self.x)
         z = [cosh(x) for x in self.x]
@@ -1900,7 +1900,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = tanh(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.tanh(x)))
+        self.assertTrue(equivalent(ux[0].x, math.tanh(x)))
     
         n = len(self.x)
         z = [tanh(x) for x in self.x]
@@ -1932,7 +1932,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = acosh(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.acosh(x)))
+        self.assertTrue(equivalent(ux[0].x, math.acosh(x)))
     
         x = [ureal(1.2, 0.02), ureal(3.1, 0.01), ureal(4.1, 0.03), ureal(2.2, 0.03)]
         xa = uarray(x)
@@ -1984,7 +1984,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = asinh(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.asinh(x)))
+        self.assertTrue(equivalent(ux[0].x, math.asinh(x)))
     
         x = [ureal(1.2, 0.02), ureal(3.1, 0.01), ureal(4.1, 0.03), ureal(2.2, 0.03)]
         xa = uarray(x)
@@ -2036,7 +2036,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ureal(x, 0.4, 7)])
         ux = atanh(a)
         self.assertTrue(isinstance(ux,UncertainArray))
-        self.assertTrue(equivalent(ux.x, math.atanh(x)))
+        self.assertTrue(equivalent(ux[0].x, math.atanh(x)))
     
         x = [ureal(0.4, 0.02), ureal(-0.3, 0.01), ureal(-0.2, 0.03), ureal(0.8, 0.03)]
         xa = uarray(x)
@@ -2088,7 +2088,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ucomplex(x, 1, 7)])
         ux = mag_squared(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, abs(x*x)))
+        self.assertTrue(equivalent(ux[0].x, abs(x*x)))
     
         for item1, item2 in [(self.x, self.xa), (self.xc, self.xca)]:
             for func in (mag_squared, np.square):
@@ -2128,7 +2128,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ucomplex(x, 1, 7)])
         ux = magnitude(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, abs(x)))
+        self.assertTrue(equivalent(ux[0].x, abs(x)))
     
         for item1, item2 in [(self.x, self.xa), (self.xc, self.xca)]:
             n = len(item1)
@@ -2160,7 +2160,7 @@ class TestUncertainArray(unittest.TestCase):
         a = uarray([ucomplex(x, 1, 7)])
         ux = phase(a)
         self.assertTrue(isinstance(ux, UncertainArray))
-        self.assertTrue(equivalent(ux.x, cmath.phase(x)))
+        self.assertTrue(equivalent(ux[0].x, cmath.phase(x)))
     
         for item1, item2 in [(self.x, self.xa), (self.xc, self.xca)]:
             n = len(item1)


### PR DESCRIPTION
There were a lot of the following warnings issued when running the tests with numpy >= 1.25 installed:

> DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
