### PR TITLE
explicitly use sphinx_rtd_theme on RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
+    'sphinx_rtd_theme',
 ]
 
 # # autodoc options
@@ -117,11 +118,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
-if on_rtd:
-    html_theme = 'default'
-else:
-    html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
ReadTheDocs changed what the "default" html theme refers to, so this explicitly sets the theme to be `sphinx_rtd_theme`. The changes in this pull request follow [these](https://sphinx-rtd-theme.readthedocs.io/en/2.0.0/installing.html#installation) instructions.

For version 1.4.1 (latest release), the docs looked like [this](https://gtc.readthedocs.io/en/stable/). However, the develop branch is currently using a different theme and look like [this](https://gtc.readthedocs.io/en/latest/).

This pull request will provide a consistent theme for the documentation of GTC 1.x; however, we may want to change the html theme for GTC 2.x.