### PR TITLE
fix Ensemble.png filename

### DIFF
--- a/docs/API/serialisation_model.rst
+++ b/docs/API/serialisation_model.rst
@@ -105,7 +105,7 @@ A few classes collect this labelled data (the collections are sets, where order 
 
     * ``Ensemble``  
 
-    .. figure:: ../images/dm/ensemble.png
+    .. figure:: ../images/dm/Ensemble.png
         :align: center
         :alt: Ensemble class
         


### PR DESCRIPTION
Since ReadTheDocs uses linux (a case-sensitive file system) to build the docs, this error was not detected when building the docs on Windows.

The issue is visible on the [latest build](https://gtc.readthedocs.io/en/latest/API/serialisation_model.html#labelled-data) on ReadTheDocs for the `Ensemble` UML diagram.