### PR TITLE
add support for Python 3.12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   PY_COLORS: 1
-  COLUMNS: 120
+  COLUMNS: 110
 
 jobs:
   test:
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, ubuntu-20.04, macos-latest]
         architecture: [x64]
         include:
@@ -39,6 +39,9 @@ jobs:
           - python-version: "3.11"
             os: windows-latest
             architecture: x86
+          - python-version: "3.12"
+            os: windows-latest
+            architecture: x86
 
     steps:
       - name: Checkout repository
@@ -60,13 +63,18 @@ jobs:
       - name: Install numpy and scipy from cgohlke repo (x86, 3.10)
         if: ${{ matrix.architecture == 'x86' && matrix.python-version == '3.10' }}
         run: |
-          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2023.7.17/numpy-1.25.1+mkl-cp310-cp310-win32.whl
-          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2023.7.17/SciPy-1.11.1-cp310-cp310-win32.whl
+          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2024.1.3/numpy-1.26.3-cp310-cp310-win32.whl
+          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2024.1.3/SciPy-1.11.4-cp310-cp310-win32.whl
       - name: Install numpy and scipy from cgohlke repo (x86, 3.11)
         if: ${{ matrix.architecture == 'x86' && matrix.python-version == '3.11' }}
         run: |
-          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2023.7.17/numpy-1.25.1+mkl-cp311-cp311-win32.whl
-          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2023.7.17/SciPy-1.11.1-cp311-cp311-win32.whl
+          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2024.1.3/numpy-1.26.3-cp311-cp311-win32.whl
+          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2024.1.3/SciPy-1.11.4-cp311-cp311-win32.whl
+      - name: Install numpy and scipy from cgohlke repo (x86, 3.12)
+        if: ${{ matrix.architecture == 'x86' && matrix.python-version == '3.12' }}
+        run: |
+          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2024.1.3/numpy-1.26.3-cp312-cp312-win32.whl
+          pip install https://github.com/cgohlke/numpy-mkl-wheels/releases/download/v2024.1.3/SciPy-1.11.4-cp312-cp312-win32.whl
       - name: Install package
         run: python -m pip install --upgrade --prefer-binary --editable .[tests]
       - name: Run tests

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development',
         'Topic :: Scientific/Engineering',
     ],


### PR DESCRIPTION
Add Python 3.12 to classifiers and to test matrix on GitHub Actions.