### PR TITLE
fix persistence.loads for older-style Archives

### DIFF
--- a/GTC/persistence.py
+++ b/GTC/persistence.py
@@ -39,6 +39,7 @@ Module contents
 import re
 import json
 import xml.etree.cElementTree as ElementTree
+from io import BytesIO
 
 try:
     import cPickle as pickle  # Python 2
@@ -194,10 +195,20 @@ def loads(s):
     
     """
     ar = pickle.loads(s)
-    ar._dump = False
-    ar._ready = False     
-    ar._thaw()
-    
+
+    # Pickle may return a new-style Archive when unpickling a string
+    # containing the old-style class (pickle takes any Archive definition).
+    if hasattr(ar, "_tagged"):
+        old = archive_old.load(BytesIO(s))
+        old._dump = False
+        old._ready = False
+        old._thaw()
+        ar = Archive._from_old_archive(old)
+    else:
+        ar._dump = False
+        ar._ready = False
+        ar._thaw()
+
     return ar
 
 #------------------------------------------------------------------     

--- a/test/test_files_v_1_3_3.py
+++ b/test/test_files_v_1_3_3.py
@@ -6,6 +6,8 @@ import json
 
 
 from GTC import *
+from GTC.context import Context
+from GTC import context
 
 #-----------------------------------------------------
 class TestArchiveJSONSchema135(unittest.TestCase):
@@ -118,57 +120,62 @@ class TestArchivePickleFilev133(unittest.TestCase):
         path = os.path.join(wdir,fname)
 
         with open(path,'rb') as f:
-            ar = persistence.load(f)
-            f.close()
+            ar1 = persistence.load(f)
 
-        x1, y1, z1 = ar.extract('x','y','z')
-        
-        self.assertEqual( repr(x1), repr(ureal(1,1)) )
-        self.assertEqual( repr(y1), repr(ureal(2,1)) )
-        self.assertEqual( repr(z1), repr( ureal(1,1) + ureal(2,1) ) )
+        context._context = Context()
 
-        z1 = ar.extract('z1')
-        
-        self.assertEqual( 
-            repr(z1), 
-            repr( 
-                ureal(1,1,3) + ureal(2,1,4) 
-            ) 
-        )
+        with open(path,'rb') as f:
+            ar2 = persistence.loads(f.read())
 
-        x1, y1, z1 = ar.extract('x2','y2','z2')
+        for ar in [ar1, ar2]:
+            x1, y1, z1 = ar.extract('x','y','z')
 
-        x = ureal(1,1,independent=False)
-        y = ureal(2,1,independent=False)
-        r = 0.5
-        set_correlation(r,x,y)
+            self.assertEqual( repr(x1), repr(ureal(1,1)) )
+            self.assertEqual( repr(y1), repr(ureal(2,1)) )
+            self.assertEqual( repr(z1), repr( ureal(1,1) + ureal(2,1) ) )
 
-        self.assertEqual( repr(x1), repr(x) )
-        self.assertEqual( repr(y1), repr(y) )
-        self.assertEqual( repr(z1), repr(x+y) )
+            z1 = ar.extract('z1')
 
-        x1, y1, z1 = ar.extract('x3','y3','z3')
+            self.assertEqual(
+                repr(z1),
+                repr(
+                    ureal(1,1,3) + ureal(2,1,4)
+                )
+            )
 
-        x,y = multiple_ureal([1,2],[1,1],4)     
-        r = 0.5
-        set_correlation(r,x,y)
-        z = result( x + y )            
-        self.assertEqual( repr(x1), repr(x) )
-        self.assertEqual( repr(y1), repr(y) )
-        self.assertEqual( repr(z1), repr(z) )
-        
-        self.assertEqual( get_correlation(x1,y1), r )
+            x1, y1, z1 = ar.extract('x2','y2','z2')
 
-        x1, y1, z1 = ar.extract('x4','y4','z4')
+            x = ureal(1,1,independent=False)
+            y = ureal(2,1,independent=False)
+            r = 0.5
+            set_correlation(r,x,y)
 
-        x = ucomplex(1,[10,2,2,10],5)
-        y = ucomplex(1-6j,[10,2,2,10],7)
-        
-        z = result( log( x * y ) )
-            
-        self.assertEqual( repr(x1), repr(x) )
-        self.assertEqual( repr(y1), repr(y) )
-        self.assertEqual( repr(z1), repr(z) )
+            self.assertEqual( repr(x1), repr(x) )
+            self.assertEqual( repr(y1), repr(y) )
+            self.assertEqual( repr(z1), repr(x+y) )
+
+            x1, y1, z1 = ar.extract('x3','y3','z3')
+
+            x,y = multiple_ureal([1,2],[1,1],4)
+            r = 0.5
+            set_correlation(r,x,y)
+            z = result( x + y )
+            self.assertEqual( repr(x1), repr(x) )
+            self.assertEqual( repr(y1), repr(y) )
+            self.assertEqual( repr(z1), repr(z) )
+
+            self.assertEqual( get_correlation(x1,y1), r )
+
+            x1, y1, z1 = ar.extract('x4','y4','z4')
+
+            x = ucomplex(1,[10,2,2,10],5)
+            y = ucomplex(1-6j,[10,2,2,10],7)
+
+            z = result( log( x * y ) )
+
+            self.assertEqual( repr(x1), repr(x) )
+            self.assertEqual( repr(y1), repr(y) )
+            self.assertEqual( repr(z1), repr(z) )
         
 #============================================================================
 if(__name__== '__main__'):

--- a/test/test_files_v_1_3_5.py
+++ b/test/test_files_v_1_3_5.py
@@ -5,6 +5,8 @@ import sys
 import json
 
 from GTC import *
+from GTC.context import Context
+from GTC import context
 
 #-----------------------------------------------------
 class TestArchiveJSONSchema135(unittest.TestCase):
@@ -123,63 +125,68 @@ class TestArchivePickleFilev135(unittest.TestCase):
         path = os.path.join(wdir,fname)
 
         with open(path,'rb') as f:
-            ar = persistence.load(f)
-            f.close()
+            ar1 = persistence.load(f)
 
-        w, x, y, z = ar.extract('w','x','y', 'z')
-        
-        _w = ureal(1,1)
-        _x = ureal(2,1)
-        self.assertEqual( repr(w), repr(_w) )
-        self.assertEqual( repr(x), repr(_x) )
-        self.assertEqual( repr(y), repr( _w + _x ) )
-        self.assertEqual( repr(z), repr( _x*(_w +_x) ) )
-        self.assertEqual( component(z,w), 2)
-        self.assertEqual( component(z,x), 5)
-        self.assertEqual( component(z,y), 2*uncertainty(_w + _x))
+        context._context = Context()
 
-        z1 = ar.extract('z1')
-        
-        self.assertEqual( 
-            repr(z1), 
-            repr( 
-                ureal(1,1,3) + ureal(2,1,4) 
-            ) 
-        )
+        with open(path,'rb') as f:
+            ar2 = persistence.loads(f.read())
 
-        x1, y1, z1 = ar.extract('x2','y2','z2')
+        for ar in [ar1, ar2]:
+            w, x, y, z = ar.extract('w','x','y', 'z')
 
-        x = ureal(1,1,independent=False)
-        y = ureal(2,1,independent=False)
-        r = 0.5
-        set_correlation(r,x,y)
+            _w = ureal(1,1)
+            _x = ureal(2,1)
+            self.assertEqual( repr(w), repr(_w) )
+            self.assertEqual( repr(x), repr(_x) )
+            self.assertEqual( repr(y), repr( _w + _x ) )
+            self.assertEqual( repr(z), repr( _x*(_w +_x) ) )
+            self.assertEqual( component(z,w), 2)
+            self.assertEqual( component(z,x), 5)
+            self.assertEqual( component(z,y), 2*uncertainty(_w + _x))
 
-        self.assertEqual( repr(x1), repr(x) )
-        self.assertEqual( repr(y1), repr(y) )
-        self.assertEqual( repr(z1), repr(x+y) )
+            z1 = ar.extract('z1')
 
-        x1, y1, z1 = ar.extract('x3','y3','z3')
+            self.assertEqual(
+                repr(z1),
+                repr(
+                    ureal(1,1,3) + ureal(2,1,4)
+                )
+            )
 
-        x,y = multiple_ureal([1,2],[1,1],4)     
-        r = 0.5
-        set_correlation(r,x,y)
-        z = result( x + y )            
-        self.assertEqual( repr(x1), repr(x) )
-        self.assertEqual( repr(y1), repr(y) )
-        self.assertEqual( repr(z1), repr(z) )
-        
-        self.assertEqual( get_correlation(x1,y1), r )
+            x1, y1, z1 = ar.extract('x2','y2','z2')
 
-        x1, y1, z1 = ar.extract('x4','y4','z4')
+            x = ureal(1,1,independent=False)
+            y = ureal(2,1,independent=False)
+            r = 0.5
+            set_correlation(r,x,y)
 
-        x = ucomplex(1,[10,2,2,10],5)
-        y = ucomplex(1-6j,[10,2,2,10],7)
-        
-        z = result( log( x * y ) )
-            
-        self.assertEqual( repr(x1), repr(x) )
-        self.assertEqual( repr(y1), repr(y) )
-        self.assertEqual( repr(z1), repr(z) )
+            self.assertEqual( repr(x1), repr(x) )
+            self.assertEqual( repr(y1), repr(y) )
+            self.assertEqual( repr(z1), repr(x+y) )
+
+            x1, y1, z1 = ar.extract('x3','y3','z3')
+
+            x,y = multiple_ureal([1,2],[1,1],4)
+            r = 0.5
+            set_correlation(r,x,y)
+            z = result( x + y )
+            self.assertEqual( repr(x1), repr(x) )
+            self.assertEqual( repr(y1), repr(y) )
+            self.assertEqual( repr(z1), repr(z) )
+
+            self.assertEqual( get_correlation(x1,y1), r )
+
+            x1, y1, z1 = ar.extract('x4','y4','z4')
+
+            x = ucomplex(1,[10,2,2,10],5)
+            y = ucomplex(1-6j,[10,2,2,10],7)
+
+            z = result( log( x * y ) )
+
+            self.assertEqual( repr(x1), repr(x) )
+            self.assertEqual( repr(y1), repr(y) )
+            self.assertEqual( repr(z1), repr(z) )
         
 #============================================================================
 if(__name__== '__main__'):


### PR DESCRIPTION
The `persistence.loads` function did not check for an older-style Archive.

Added tests.