### PR TITLE
change how the JSON deprecation message is implemented

### DIFF
--- a/GTC/json_format_old.py
+++ b/GTC/json_format_old.py
@@ -3,7 +3,6 @@ This module handles conversion of an archive object to a JSON format
 and then restoration of an archive from JSON.
 """
 import json
-from GTC.deprecated import *
 
 from GTC.archive_old import (
     Archive,

--- a/GTC/json_format_old.py
+++ b/GTC/json_format_old.py
@@ -155,12 +155,7 @@ class JSONArchiveEncoder(json.JSONEncoder):
             
 #----------------------------------------------------------------------------
 # 
-@deprecated(
-    reason="Support for the legacy JSON format (prior to GTC v1.5) is being dropped.",
-    deprecated_in="1.5",
-    remove_in="2.0"
-)
-def json_to_archive(j): 
+def json_to_archive(j):
     """
     Called during retrieval of an archive in JSON format by `json.loads()`
     The function is called, when `loads()` parses the JSON record, every time 

--- a/GTC/persistence.py
+++ b/GTC/persistence.py
@@ -49,6 +49,7 @@ except ImportError:
 
 from GTC import archive_old
 from GTC.deprecated import *
+from GTC.deprecated import _warn
 
 from GTC.archive import Archive
 
@@ -231,12 +232,15 @@ def loads_json(s,**kw):
     pattern = r'"version": "{}"'.format(
         re.sub(r'\.', r'\.',JSON_SCHEMA)
     )
+    stacklevel = kw.pop('stacklevel', 3)
     if re.search(pattern, s):
         ar = json.loads(s,object_hook=json_to_archive,**kw)    
         # ar._dump = False
         # ar._ready = False     
         ar._thaw()
     else:
+        _warn('Support for the legacy JSON format (prior to GTC v1.5) is being dropped in GTC v2.0',
+              stacklevel=stacklevel)
         old = json_format_old.json.loads(
             s,
             object_hook=json_format_old.json_to_archive,
@@ -280,7 +284,7 @@ def load_json(file,**kw):
     .. versionadded:: 1.3.0
     """
     s = file.read()
-    ar = loads_json(s,**kw)
+    ar = loads_json(s, stacklevel=4, **kw)
     
     return ar
 


### PR DESCRIPTION
The following script is used to justify the changes
```python
# scratch.py
from GTC import persistence

with open('test/ref_file_v_1_3_3.json', 'r') as f:
    persistence.load_json(f)

with open('test/ref_file_v_1_3_5.json', 'r') as f:
    persistence.load_json(f)

with open('test/ref_file_v_1_3_3.json', 'r') as f:
    persistence.loads_json(f.read())

with open('test/ref_file_v_1_3_5.json', 'r') as f:
    persistence.loads_json(f.read())
```
Running this script with the `develop` branch produces the following output
```console
...\Python312\Lib\json\decoder.py:353: GTCDeprecationWarning: The function `json_to_archive` is deprecated since version 1.5 and is planned for removal in version 2.0. Support for the legacy JSON format (prior to GTC v1.5) is being dropped.
  obj, end = self.scan_once(s, idx)
```
The warning references the `json_to_archive` function (only once) which points to the builtin `self.scan_once` method in the `json.decoder` module.

Running the script with this branch produces the following output
```console
...\scratch.py:5: GTCDeprecationWarning: Support for the legacy JSON format (prior to GTC v1.5) is being dropped in GTC v2.0
  persistence.load_json(f)
...\scratch.py:8: GTCDeprecationWarning: Support for the legacy JSON format (prior to GTC v1.5) is being dropped in GTC v2.0
  persistence.load_json(f)
...\scratch.py:11: GTCDeprecationWarning: Support for the legacy JSON format (prior to GTC v1.5) is being dropped in GTC v2.0
  persistence.loads_json(f.read())
...\scratch.py:14: GTCDeprecationWarning: Support for the legacy JSON format (prior to GTC v1.5) is being dropped in GTC v2.0
  persistence.loads_json(f.read())
```
The warning points to the line in the user's code that caused the warning and occurs 4x (once for each call).