### PR TITLE
use implicit unicode strings

### DIFF
--- a/GTC/formatting.py
+++ b/GTC/formatting.py
@@ -53,21 +53,19 @@ _format_spec_regex = re.compile(
 
 _exponent_regex = re.compile(r'[eE][+-]\d+')
 
-# TODO replace u'' with '' when dropping support for
-#  Python 2.7. There are multiple occurrences in this module.
 _unicode_superscripts = {
-    ord('+'): u'\u207A',
-    ord('-'): u'\u207B',
-    ord('0'): u'\u2070',
-    ord('1'): u'\u00B9',
-    ord('2'): u'\u00B2',
-    ord('3'): u'\u00B3',
-    ord('4'): u'\u2074',
-    ord('5'): u'\u2075',
-    ord('6'): u'\u2076',
-    ord('7'): u'\u2077',
-    ord('8'): u'\u2078',
-    ord('9'): u'\u2079',
+    ord('+'): '\u207A',
+    ord('-'): '\u207B',
+    ord('0'): '\u2070',
+    ord('1'): '\u00B9',
+    ord('2'): '\u00B2',
+    ord('3'): '\u00B3',
+    ord('4'): '\u2074',
+    ord('5'): '\u2075',
+    ord('6'): '\u2076',
+    ord('7'): '\u2077',
+    ord('8'): '\u2078',
+    ord('9'): '\u2079',
 }
 
 _Rounded = namedtuple('Rounded', 'value precision type exponent suffix')
@@ -150,10 +148,7 @@ class Format(object):
         fmt = '{fill}{align}{zero}{width}s'.format(
             fill=self._fill, align=self._align,
             zero=self._zero, width=self._width)
-        try:
-            return u'{0:{1}}'.format(text, fmt)
-        except UnicodeError:
-            return '{0:{1}}'.format(text, fmt)
+        return '{0:{1}}'.format(text, fmt)
 
     def _value(self, value, precision=None, type=None, sign=None, hash=None):
         """Format a value.
@@ -480,7 +475,7 @@ def to_string(obj, fmt):
         im_str = _stylize(im_val + i.suffix, fmt)
 
         b1, b2 = _stylize('(', fmt), _stylize(')', fmt)
-        result = u'{0}{1}{2}j{3}'.format(b1, re_str, im_str, b2)
+        result = '{0}{1}{2}j{3}'.format(b1, re_str, im_str, b2)
         if fmt._type == '%':
             result = move_percent_symbol(result)
         return fmt._result(result)
@@ -496,7 +491,7 @@ def to_string(obj, fmt):
     if imag is not None:
         imag_str = _to_string_ureal(imag, fmt, sign='+')
         b1, b2 = _stylize('(', fmt), _stylize(')', fmt)
-        result = u'{0}{1}{2}j{3}'.format(b1, result, _stylize(imag_str, fmt), b2)
+        result = '{0}{1}{2}j{3}'.format(b1, result, _stylize(imag_str, fmt), b2)
         if fmt._type == '%':
             result = move_percent_symbol(result)
 
@@ -607,9 +602,9 @@ def _stylize(text, fmt):
 
     if fmt._style == 'U':
         if exp_match and exp_number != 0:
-            e = u'{}'.format(exp_number)
+            e = '{}'.format(exp_number)
             translated = e.translate(_unicode_superscripts)
-            exponent = u'\u00D710{}'.format(translated)
+            exponent = '\u00D710{}'.format(translated)
 
     elif fmt._style == 'L':
         if exp_match and exp_number != 0:
@@ -630,7 +625,7 @@ def _stylize(text, fmt):
 
     if exp_match:
         start, end = exp_match.span()
-        text = u'{0}{1}{2}'.format(text[:start], exponent, text[end:])
+        text = '{0}{1}{2}'.format(text[:start], exponent, text[end:])
 
     for old, new in replacements:
         text = text.replace(old, new)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,9 @@ from GTC import version, copyright
 
 # -- Project information -----------------------------------------------------
 
-project = u'GUM Tree Calculator'
+project = 'GUM Tree Calculator'
 copyright =copyright
-author = u'Measurement Standards Laboratory of New Zealand'
+author = 'Measurement Standards Laboratory of New Zealand'
 
 # The short X.Y version
 version = version
@@ -101,7 +101,7 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
@@ -191,8 +191,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'GUMTreeCalculator.tex', u'GUM Tree Calculator Documentation',
-     u'Measurement Standards Laboratory of New Zealand', 'manual'),
+    (master_doc, 'GUMTreeCalculator.tex', 'GUM Tree Calculator Documentation',
+     'Measurement Standards Laboratory of New Zealand', 'manual'),
 ]
 
 
@@ -201,7 +201,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'gumtreecalculator', u'GUM Tree Calculator Documentation',
+    (master_doc, 'gumtreecalculator', 'GUM Tree Calculator Documentation',
      [author], 1)
 ]
 
@@ -212,7 +212,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'GUMTreeCalculator', u'GUM Tree Calculator Documentation',
+    (master_doc, 'GUMTreeCalculator', 'GUM Tree Calculator Documentation',
      author, 'GUMTreeCalculator', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1760,16 +1760,16 @@ class TestFormatting(unittest.TestCase):
 
         for t in ['e', 'E']:
             fmt = create_format(ur, digits=2, type=t, style='U')
-            self.assertEqual(to_string(ur, fmt),   u'1.854(94)×10¹')
-            self.assertEqual(to_string(ur.x, fmt), u'1.854×10¹')
-            self.assertEqual(to_string(ur.u, fmt), u'9.4×10⁻¹')
+            self.assertEqual(to_string(ur, fmt),   '1.854(94)×10¹')
+            self.assertEqual(to_string(ur.x, fmt), '1.854×10¹')
+            self.assertEqual(to_string(ur.u, fmt), '9.4×10⁻¹')
 
         ur = ureal(1.23456789, 0.123456789)
         self.assertEqual('{:.3eU}'.format(ur), '1.235(123)')
-        self.assertEqual(u'{:.3EU}'.format(ur * 1e-6), u'1.235(123)×10⁻⁶')
-        self.assertEqual(u'{:.3EU}'.format(ur * 1e12), u'1.235(123)×10¹²')
-        self.assertEqual(u'{:.3eU}'.format(ur * 1e100), u'1.235(123)×10¹⁰⁰')
-        self.assertEqual(u'{:.3EU}'.format(ur * 1e-100), u'1.235(123)×10⁻¹⁰⁰')
+        self.assertEqual('{:.3EU}'.format(ur * 1e-6), '1.235(123)×10⁻⁶')
+        self.assertEqual('{:.3EU}'.format(ur * 1e12), '1.235(123)×10¹²')
+        self.assertEqual('{:.3eU}'.format(ur * 1e100), '1.235(123)×10¹⁰⁰')
+        self.assertEqual('{:.3EU}'.format(ur * 1e-100), '1.235(123)×10⁻¹⁰⁰')
 
         uc = ucomplex(18.5424+1.2j, 0.94271)
 
@@ -1781,9 +1781,9 @@ class TestFormatting(unittest.TestCase):
 
         for t in ['e', 'E']:
             fmt = create_format(uc, digits=2, type=t, style='U')
-            self.assertEqual(to_string(uc, fmt),   u'(1.854(94)×10¹+1.20(94)j)')
-            self.assertEqual(to_string(uc.x, fmt), u'(1.854×10¹+1.20j)')
-            self.assertEqual(to_string(uc.u, fmt), u'(9.4×10⁻¹+9.4×10⁻¹j)')
+            self.assertEqual(to_string(uc, fmt),   '(1.854(94)×10¹+1.20(94)j)')
+            self.assertEqual(to_string(uc.x, fmt), '(1.854×10¹+1.20j)')
+            self.assertEqual(to_string(uc.u, fmt), '(9.4×10⁻¹+9.4×10⁻¹j)')
 
     @unittest.skipIf(sys.version_info.major == 2, 'not supported for this version of Python')
     def test_hash_symbol(self):


### PR DESCRIPTION
Replaces all occurrences of strings like `u"<any string>"` with `"<any string>"`, as using `u""` is irrelevant in Python 3+.