### PR TITLE
Remove redundant future statements

### DIFF
--- a/GTC/LU.py
+++ b/GTC/LU.py
@@ -6,7 +6,6 @@ Provides LU decomposition functions for Python objects stored in 2D arrays.
 :func:`ludcmp` performs LU decomposition
 :func:`invab` 
 """
-from __future__ import division
 from functools import reduce
 try:
     xrange  # Python 2

--- a/GTC/__init__.py
+++ b/GTC/__init__.py
@@ -6,8 +6,6 @@ The method of uncertainty propagation is compatible with the approach described
 in the 'Guide to the Expression of Uncertainty in Measurement' - the GUM.
 
 """
-from __future__ import division
-
 import math
 import cmath
 import sys 

--- a/GTC/core.py
+++ b/GTC/core.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import math
 import cmath
 import numbers

--- a/GTC/function.py
+++ b/GTC/function.py
@@ -14,8 +14,6 @@ Module contents
 ---------------
 
 """
-from __future__ import division
-
 import math
 import numpy as np 
 from GTC.type_b import mean 

--- a/GTC/lib.py
+++ b/GTC/lib.py
@@ -968,18 +968,12 @@ class UncertainReal(object):
 
     #------------------------------------------------------------------------
     def __truediv__(self,rhs):
-        return self.__div__(rhs)
-        
-    def __div__(self,rhs):
         if isinstance(rhs,(UncertainReal,numbers.Complex)):
             return _div(self,rhs)
         else:
             return NotImplemented
 
     def __rtruediv__(self,lhs):
-        return self.__rdiv__(lhs)
-        
-    def __rdiv__(self,lhs):
         if isinstance(lhs,numbers.Complex):
             return _rdiv(lhs,self)
         else:
@@ -3260,9 +3254,6 @@ class UncertainComplex(object):
 
     #------------------------------------------------------------------------
     def __truediv__(self,rhs):
-        return self.__div__(rhs)
-        
-    def __div__(self,rhs):
         lhs = self
         if isinstance(rhs,UncertainComplex):
             l = lhs._value
@@ -3318,9 +3309,6 @@ class UncertainComplex(object):
             return NotImplemented
  
     def __rtruediv__(self,lhs):
-        return self.__rdiv__(lhs)
-        
-    def __rdiv__(self,lhs):
         rhs = self
         if isinstance(lhs,UncertainReal):
             r = rhs._value

--- a/GTC/lib.py
+++ b/GTC/lib.py
@@ -3,8 +3,6 @@ Defines :class:`UncertainReal` and implements the mathematical
 operations on this class of objects.
 
 """
-from __future__ import division
-
 import math
 import cmath
 import numbers

--- a/GTC/reporting.py
+++ b/GTC/reporting.py
@@ -44,8 +44,6 @@ Module contents
 ---------------
 
 """
-from __future__ import division     # True division
-
 import math
 import numbers
 

--- a/GTC/type_a.py
+++ b/GTC/type_a.py
@@ -50,8 +50,6 @@ Module contents
 ---------------
 
 """
-from __future__ import division
-
 import sys
 import math
 import numbers

--- a/GTC/type_b.py
+++ b/GTC/type_b.py
@@ -69,8 +69,6 @@ Module contents
 ---------------
 
 """
-from __future__ import division
-
 import sys
 import math
 

--- a/GTC/uncertain_array.py
+++ b/GTC/uncertain_array.py
@@ -4,8 +4,6 @@ The proper way to create an uncertain array is by calling :func:`.uarray`
 # Adding numpy arrays to GTC is not an easy exercise.
 # Our need is to provide convenient containers for uncertain numbers.
 # We do not try to integrate uncertain numbers in numpy's design.
-from __future__ import division
-
 import warnings
 
 from numbers import Number, Real, Complex

--- a/GTC/uncertain_array.py
+++ b/GTC/uncertain_array.py
@@ -528,9 +528,6 @@ class UncertainArray(np.ndarray):
         return UncertainArray(arr)
 
     def _divide(self, *inputs):
-        return self._true_divide(*inputs)
-
-    def _true_divide(self, *inputs):
         arr, itemset, iterator = self._create_empty(inputs)
         for i, (a, b) in enumerate(iterator):
             itemset(i, a / b)

--- a/examples/GUM_H1.py
+++ b/examples/GUM_H1.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from GTC import *
 
 print("""

--- a/examples/GUM_H2.py
+++ b/examples/GUM_H2.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from GTC import *
 
 print("""

--- a/examples/GUM_H3.py
+++ b/examples/GUM_H3.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from GTC import *
 
 print("""

--- a/examples/GUM_H3_systematic.py
+++ b/examples/GUM_H3_systematic.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from GTC import *
 
 print("""

--- a/test/test_uncertain_real.py
+++ b/test/test_uncertain_real.py
@@ -716,7 +716,7 @@ class ArithmeticTestsReal(unittest.TestCase):
         y = 1.0 / self.w
         self.assertTrue( y is not self.w )
         
-        self.assertRaises(ZeroDivisionError,UncertainReal.__div__, self.z, 0)
+        self.assertRaises(ZeroDivisionError,UncertainReal.__truediv__, self.z, 0)
 
         newy = y/(1.0+0j)
         self.assertFalse( newy is y )


### PR DESCRIPTION
From the Python [docs](https://docs.python.org/3/reference/simple_stmts.html#future-statements):

> All historical features enabled by the future statement are still recognized by Python 3. The list includes `absolute_import`, `division`, `generators`, `generator_stop`, `unicode_literals`, `print_function`, `nested_scopes` and `with_statement`. They are all redundant because they are always enabled, and only kept for backwards compatibility.

GTC imported `division` and `print_function` so these `__future__` imports have been removed.

Also, [object.\_\_[r]div\_\_](https://docs.python.org/2/reference/datamodel.html?highlight=__div__#object.__div__) are no longer attributes of `object` in Python 3, so they have also been removed since [object.\_\_[r]truediv\_\_](https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types) is all that is required.

For the `UncertainArray` change, _true_divide_ is not a numpy ufunc name. numpy uses _divide_ as the ufunc name for _true division_, so it makes sense to delete the `_true_divide()` method and to keep the `_divide()` method. I originally created `_true_divide()` to keep the terminology consistent with `UncertainReal` and `UncertainComplex`.