### PR TITLE
Convert to f-string

### DIFF
--- a/GTC/LU.py
+++ b/GTC/LU.py
@@ -45,11 +45,11 @@ def ludcmp(a):
     """
     if len(a.shape) != 2:
         raise RuntimeError( 
-            "A 2D array is needed, got  shape={}".format(a.shape)
+            f"A 2D array is needed, got  shape={a.shape}"
         )
     elif a.shape[0] != a.shape[1]:
         raise RuntimeError( 
-            "A square array is needed, shape={}".format(a.shape)
+            f"A square array is needed, shape={a.shape}"
         )
         
     N = a.shape[0]
@@ -166,12 +166,11 @@ def invab(a,b):
     
     """
     # Required by _lubksb
-    assert a.dtype == b.dtype,\
-        "{} != {}".format(a.dtype, b.dtype)
+    assert a.dtype == b.dtype, f"{a.dtype} != {b.dtype}"
         
     if len(b.shape) != 2:
         raise RuntimeError( 
-            "A 2D array is needed for `b`, got  shape={}".format(b.shape)
+            f"A 2D array is needed for `b`, got  shape={b.shape}"
         )
     # `a` shape is checked when `ludcmp` is called 
     a_lu,idx,p = ludcmp(a.copy())
@@ -208,11 +207,11 @@ def ludet(a_lu,p):
     Nx,Ny = a_lu.shape
     if Nx != Ny:
         raise RuntimeError(
-            "matrix must be square, got {}".format(a_lu.shape)
+            f"matrix must be square, got {a_lu.shape}"
         )
     elif p not in (1,-1):
         raise RuntimeError(
-            "parity must be +/- 1, got {!r}".format(p)
+            f"parity must be +/- 1, got {p!r}"
         )
         
     return reduce(
@@ -232,8 +231,7 @@ def solve(a,b):
 
     """
     # Required by _lubksb
-    assert a.dtype == b.dtype,\
-        "{} != {}".format(a.dtype, b.dtype)
+    assert a.dtype == b.dtype, f"{a.dtype} != {b.dtype}"
         
     a_lu,i,p = ludcmp( a.copy() )
     return _lubksb( a_lu,i,b.copy() )

--- a/GTC/__init__.py
+++ b/GTC/__init__.py
@@ -101,10 +101,9 @@ __all__ = (
 #----------------------------------------------------------------------------
 if sys.version_info[:2] < (3, 8):
     import warnings
-    major, minor = sys.version_info[:2]
     warnings.simplefilter('once', DeprecationWarning)
     warnings.warn(
-        f'GTC will stop supporting Python {major}.{minor} in GTC version 2.0. '
+        f'GTC will stop supporting Python {sys.version_info.major}.{sys.version_info.minor} in GTC version 2.0. '
         f'GTC 2.0 will require Python 3.8, or above. '
         f'Please update your version of Python.',
         DeprecationWarning,

--- a/GTC/__init__.py
+++ b/GTC/__init__.py
@@ -101,11 +101,12 @@ __all__ = (
 #----------------------------------------------------------------------------
 if sys.version_info[:2] < (3, 8):
     import warnings
+    major, minor = sys.version_info[:2]
     warnings.simplefilter('once', DeprecationWarning)
     warnings.warn(
-        'GTC will stop supporting Python %d.%d in GTC version 2.0. '
-        'GTC 2.0 will require Python 3.8, or above. '
-        'Please update your version of Python.' % sys.version_info[:2],
+        f'GTC will stop supporting Python {major}.{minor} in GTC version 2.0. '
+        f'GTC 2.0 will require Python 3.8, or above. '
+        f'Please update your version of Python.',
         DeprecationWarning,
         stacklevel=2
     )

--- a/GTC/archive.py
+++ b/GTC/archive.py
@@ -307,14 +307,14 @@ class Archive(object):
         if self._dump and self._ready:
             if key in self._tagged_real or key in self._tagged_complex:
                 raise RuntimeError(
-                    "The tag '{!s}' is already in use".format(key)
+                    f"The tag '{key}' is already in use"
                 )
             else:
                 # This uncertain-number object can be elementary or intermediate
                 if isinstance(obj,UncertainReal):
                     if key in self._untagged_real:
                         raise RuntimeError(
-                            "The tag '{!s}' is being used".format(key)
+                            f"The tag '{key}' is being used"
                         )
                         
                     # An intermediate UncertainReal needs to be recorded
@@ -323,7 +323,7 @@ class Archive(object):
                             uid = obj._node.uid
                         except AttributeError:
                             raise RuntimeError(
-                                "uncertain number labelled '{}' is not declared intermediate".format(key)
+                                f"uncertain number labelled '{key}' is not declared intermediate"
                             )
                         self._uid_to_intermediate[uid] = obj            
                     
@@ -331,16 +331,16 @@ class Archive(object):
 
                 elif isinstance(obj,UncertainComplex):
                 
-                    n_re = "{!s}_re".format(key)
+                    n_re = f"{key}_re"
                     if n_re in self._tagged_real or n_re in self._untagged_real:
                         raise RuntimeError(
-                            "'{!s}' is being used as a name-tag".format(n_re)
+                            f"{n_re!r} is being used as a name-tag"
                         )
 
-                    n_im = "{!s}_im".format(key)
+                    n_im = f"{key}_im"
                     if n_im in self._tagged_real or n_im in self._untagged_real:
                         raise RuntimeError(
-                            "'{!s}' is being used as a name-tag".format(n_im)
+                            f"{n_im!r} is being used as a name-tag"
                         )
                         
                     self._untagged_real[n_re] = obj.real
@@ -354,7 +354,7 @@ class Archive(object):
                             uid_i = obj.imag._node.uid
                         except AttributeError:
                             raise RuntimeError(
-                                "uncertain number labelled '{}' is not declared intermediate".format(key)
+                                f"uncertain number labelled '{key}' is not declared intermediate"
                             )
                             
                         self._uid_to_intermediate[uid_r] = obj.real
@@ -364,7 +364,7 @@ class Archive(object):
                     
                 else:
                     raise RuntimeError(
-                        "'{!r}' cannot be archived: wrong type".format(obj)
+                        f"'{obj!r}' cannot be archived: wrong type"
                     )
         else:
             raise RuntimeError('Archive cannot be added to')
@@ -430,7 +430,7 @@ class Archive(object):
                 return self._tagged_complex[key]
             else:
                 raise RuntimeError(
-                    "'{!s}' not found".format(key)
+                    f"{key!r} not found"
                 )
             
         else:
@@ -564,10 +564,10 @@ class Archive(object):
                             uid=obj.imag._node.uid
                         )
                         
-                        n_re = "{}_re".format(n)
+                        n_re = f"{n}_re"
                         self._untagged_real[n_re] = re
                         
-                        n_im = "{}_im".format(n)
+                        n_im = f"{n}_im"
                         self._untagged_real[n_im] = im 
                         
                         self._tagged_complex[n] = Complex(
@@ -609,7 +609,7 @@ class Archive(object):
                             uid = obj.real._node.uid,
                         )
                             
-                        n_re = "{}_re".format(n)
+                        n_re = f"{n}_re"
                         self._untagged_real[n_re] = re
                         
                         im = IntermediateReal(
@@ -626,7 +626,7 @@ class Archive(object):
                             uid = obj.imag._node.uid,
                         )
 
-                        n_im = "{}_im".format(n)
+                        n_im = f"{n}_im"
                         self._untagged_real[n_im] = im
                         
                         self._tagged_complex[n] = Complex(
@@ -845,7 +845,7 @@ def _builder(o_name,_nodes,_tagged_real):
         _tagged_real[o_name] = un
 
     else:
-        assert False, "unexpected: {!r}".format(obj)
+        assert False, f"unexpected: {obj!r}"
 
     return un
 

--- a/GTC/archive.py
+++ b/GTC/archive.py
@@ -405,7 +405,7 @@ class Archive(object):
         .. invisible-code-block: pycon
         
             >>> import tempfile
-            >>> f = open(tempfile.gettempdir() + '/GTC-archive-test.json', 'wt')
+            >>> f = open(f'{tempfile.gettempdir()}/GTC-archive-test.json', 'wt')
 
         Here ``f`` is a file stream opened in mode 'wt':
         
@@ -461,7 +461,7 @@ class Archive(object):
         .. invisible-code-block: pycon
 
             >>> import tempfile
-            >>> f = open(tempfile.gettempdir() + '/GTC-archive-test.json', 'rt')
+            >>> f = open(f'{tempfile.gettempdir()}/GTC-archive-test.json', 'rt')
             
         .. code-block:: pycon
         
@@ -481,7 +481,7 @@ class Archive(object):
         .. invisible-code-block: pycon
             
             >>> import os, tempfile
-            >>> os.remove(tempfile.gettempdir() + '/GTC-archive-test.json')
+            >>> os.remove(f'{tempfile.gettempdir()}/GTC-archive-test.json')
   
         """        
         lst = [ self._getitem(n) for n in args ]               

--- a/GTC/context.py
+++ b/GTC/context.py
@@ -119,7 +119,7 @@ class Context(object):
             )
             if not OK:
                 raise RuntimeError(
-                    "the Leaf node uid({}) is in use already".format(uid)
+                    f"the Leaf node uid({uid}) is in use already"
                 )
         else:          
             l = Leaf(uid,label,u,df,independent)
@@ -151,9 +151,7 @@ class Context(object):
             )
             if not OK:
                 raise RuntimeError(
-                    "intermediate node uid({}), '{}', u={}, df={} is used".format(
-                        uid,label,u,df
-                    )
+                    f"intermediate node uid({uid}), {label!r}, u={u}, df={df} is used"
                 )
         else:          
             n = Node(uid,label,u,df)

--- a/GTC/core.py
+++ b/GTC/core.py
@@ -309,14 +309,14 @@ def ureal(x,u,df=inf,label=None,independent=True):
     """    
     # Arguments to these math functions must be compatible with float
     if math.isnan(x) or math.isinf(x):
-        raise ValueError("invalid: '{!r}'".format(x) )
+        raise ValueError(f"invalid: '{x!r}'" )
 
     if u < 0 or math.isinf(u) or math.isnan(u):
-        raise ValueError("invalid uncertainty: '{!r}'".format(u) )
+        raise ValueError(f"invalid uncertainty: '{u!r}'" )
 
     # inf is allowed, but not nan
     if df < 1 or math.isnan(df):
-        raise ValueError("invalid dof: '{!r}'".format(df) )
+        raise ValueError(f"invalid dof: '{df!r}'" )
     
     if u == 0:
         # Is this what we want? Perhaps not.
@@ -370,7 +370,7 @@ def multiple_ureal(x_seq,u_seq,df,label_seq=None):
     """
     if len(x_seq) != len(u_seq):
         raise RuntimeError(
-            "unequal length sequences: x={!r} u={!r}".format(x_seq,u_seq)
+            f"unequal length sequences: x={x_seq!r} u={u_seq!r}"
         )
 
     if label_seq is None:
@@ -378,11 +378,11 @@ def multiple_ureal(x_seq,u_seq,df,label_seq=None):
     elif is_sequence(label_seq):
         if len(x_seq) != len(label_seq):
             raise RuntimeError(
-                "unequal length sequences: x={!r} label_seq={!r}".format(x_seq,u_seq)
+                f"unequal length sequences: x={x_seq!r} label_seq={u_seq!r}"
             )
     else:
         raise RuntimeError(
-            "invalid `label_seq`: {!r}".format(label_seq)
+            f"invalid `label_seq`: {label_seq!r}"
         )
         
     rtn = [
@@ -431,7 +431,7 @@ def constant(x,label=None):
         return UncertainComplex._constant(x,label)
     else:
         raise TypeError(
-            "Cannot make a constant: {!r}".format( x )
+            f"Cannot make a constant: {x!r}"
         )
   
 #----------------------------------------------------------------------------
@@ -480,8 +480,8 @@ def result(un,label=None):
         # This covers any pure number type
         if label is not None:
             warnings.warn(
-                "A label cannot be applied to a pure number by result():"
-                " the label {!r} has been ignored".format(label),
+                f"A label cannot be applied to a pure number by result():"
+                f" the label {label!r} has been ignored",
                 RuntimeWarning
             )
         
@@ -489,7 +489,7 @@ def result(un,label=None):
         
     else:
         raise TypeError(
-            "undefined for {!r}'".format(un)
+            f"undefined for {un!r}"
         )
           
 
@@ -540,10 +540,10 @@ def ucomplex(z,u,df=inf,label=None,independent=True):
     # Arguments to these math functions must be compatible with float
     # otherwise a TypeError is raised by Python
     if cmath.isnan(z) or cmath.isinf(z):
-        raise ValueError("invalid: '{!r}'".format(z) )
+        raise ValueError(f"invalid: '{z!r}'" )
         
     if df < 1 or math.isnan(df):
-        raise ValueError("invalid dof: '{!r}'".format(df) )
+        raise ValueError(f"invalid dof: '{df!r}'" )
         
     if is_sequence(u):
     
@@ -560,7 +560,7 @@ def ucomplex(z,u,df=inf,label=None,independent=True):
             # nan != nan is True
             if math.isinf(cv1) or cv1 != cv2:
                 raise ValueError(
-                    "covariance elements not equal: {!r} and {!r}".format(cv1,cv2) 
+                    f"covariance elements not equal: {cv1!r} and {cv2!r}" 
                 )
                 
             # Note that for cv1 to be non-zero, both u_r and u_i must be non-zero
@@ -571,7 +571,7 @@ def ucomplex(z,u,df=inf,label=None,independent=True):
             # Allow a little tolerance for numerical imprecision
             if r is not None and abs(r) > 1 + 1E-10:
                 raise ValueError(
-                    "invalid correlation: {!r}, cv={}".format(r,u)
+                    f"invalid correlation: {r!r}, cv={u}"
                 )
             if r is not None:
                 # This overrides an initial assignment
@@ -579,22 +579,22 @@ def ucomplex(z,u,df=inf,label=None,independent=True):
                 
         else:
             raise ValueError(
-                "invalid uncertainty sequence: '{!r}'".format(u)
+                f"invalid uncertainty sequence: '{u!r}'"
             )
         
     elif not math.isinf(u) and not math.isnan(u):
         u_r = u_i = float(u)
         r = None
     else:
-        raise TypeError("invalid uncertainty: '{!r}'".format(u) )
+        raise TypeError(f"invalid uncertainty: '{u!r}'" )
 
     # Checking of valid uncertainty values
     # Note, comparisons with nan are always false
     if not( 0 <= u_r and u_r < inf ):
-        raise ValueError("invalid real uncertainty: '{!r}'".format(u_r) )
+        raise ValueError(f"invalid real uncertainty: '{u_r!r}'" )
 
     if not ( 0 <= u_i and u_i < inf ):
-        raise ValueError("invalid imag uncertainty: '{!r}'".format(u_i) )
+        raise ValueError(f"invalid imag uncertainty: '{u_i!r}'" )
         
     # TODO: is this what we want? Perhaps not!
     if u_r == 0 and u_i == 0:
@@ -647,7 +647,7 @@ def multiple_ucomplex(x_seq,u_seq,df,label_seq=None):
     """
     if len(x_seq) != len(u_seq):
         raise RuntimeError(
-            "unequal length sequences: x={!r} u={!r}".format(x_seq,u_seq)
+            f"unequal length sequences: x={x_seq!r} u={u_seq!r}"
         )
  
     if label_seq is None:
@@ -655,11 +655,11 @@ def multiple_ucomplex(x_seq,u_seq,df,label_seq=None):
     elif is_sequence(label_seq):
         if len(x_seq) != len(label_seq):
             raise RuntimeError(
-                "unequal length sequences: x={!r} label_seq={!r}".format(x_seq,u_seq)
+                f"unequal length sequences: x={x_seq!r} label_seq={u_seq!r}"
             )
     else:
         raise RuntimeError(
-            "invalid `label_seq`: {!r}".format(label_seq)
+            f"invalid `label_seq`: {label_seq!r}"
         )
  
     rtn = [
@@ -749,9 +749,7 @@ def set_correlation(r,arg1,arg2=None):
         arg1.set_correlation(r,arg2)
     else:
         raise TypeError(
-            "illegal arguments: {}, {}, {}".format( 
-                repr(r), repr(arg1), repr(arg2) 
-            )
+            f"illegal arguments: {r!r}, {arg1!r}, {arg2!r}"
         )
 
 #---------------------------------------------------------------------------
@@ -781,7 +779,7 @@ def get_correlation(arg1,arg2=None):
         
     else:
         raise TypeError(
-            "illegal first argument {!r}".format(arg1)
+            f"illegal first argument {arg1!r}"
         )
         
 #---------------------------------------------------------------------------
@@ -810,7 +808,7 @@ def get_covariance(arg1,arg2=None):
         
     else:
         raise TypeError(
-            "illegal first argument {!r}".format(arg1)
+            f"illegal first argument {arg1!r}"
         )
         
 #---------------------------------------------------------------------------
@@ -833,7 +831,7 @@ def log(x):
             return cmath.log(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
     
 #---------------------------------------------------------------------------
@@ -856,7 +854,7 @@ def log10(x):
             return cmath.log10(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
     
 #---------------------------------------------------------------------------
@@ -874,7 +872,7 @@ def exp(x):
             return cmath.exp(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
     
 #---------------------------------------------------------------------------
@@ -921,7 +919,7 @@ def sqrt(x):
             return cmath.sqrt(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
 
 #----------------------------------------------------------------------------
@@ -939,7 +937,7 @@ def sin(x):
             return cmath.sin(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
 
 #----------------------------------------------------------------------------
@@ -957,7 +955,7 @@ def cos(x):
             return cmath.cos(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
 #----------------------------------------------------------------------------
 def tan(x):
@@ -974,7 +972,7 @@ def tan(x):
             return cmath.tan(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
 
 #---------------------------------------------------------------------------
@@ -1012,7 +1010,7 @@ def asin(x):
             return cmath.asin(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
 #---------------------------------------------------------------------------
 def acos(x):
@@ -1049,7 +1047,7 @@ def acos(x):
             return cmath.acos(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
             
 #---------------------------------------------------------------------------
@@ -1075,7 +1073,7 @@ def atan(x):
             return cmath.atan(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
             
 #----------------------------------------------------------------------------
@@ -1112,7 +1110,7 @@ def atan2(y,x):
                 return math.atan2(y,x)
             else:
                 raise TypeError(
-                    "illegal arguments: x={!r} y={!r}".format(x,y)
+                    f"illegal arguments: x={x!r} y={y!r}"
                 )
 
 #---------------------------------------------------------------------------
@@ -1130,7 +1128,7 @@ def sinh(x):
             return cmath.sinh(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
 #---------------------------------------------------------------------------
 def cosh(x):
@@ -1147,7 +1145,7 @@ def cosh(x):
             return cmath.cosh(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
     
 #---------------------------------------------------------------------------
@@ -1165,7 +1163,7 @@ def tanh(x):
             return cmath.tanh(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
             
 #---------------------------------------------------------------------------
@@ -1192,7 +1190,7 @@ def asinh(x):
             return cmath.asinh(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
 
 #---------------------------------------------------------------------------
@@ -1215,7 +1213,7 @@ def acosh(x):
             return cmath.acosh(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
 
 #---------------------------------------------------------------------------
@@ -1240,7 +1238,7 @@ def atanh(x):
             return cmath.atanh(x)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(x)
+                f"illegal argument: {x!r}"
             )
             
 #----------------------------------------------------------------------------
@@ -1276,7 +1274,7 @@ def phase(z):
             return cmath.phase(z)
         else:
             raise TypeError(
-                "illegal argument: {!r}".format(z)
+                f"illegal argument: {z!r}"
             )
 
 #---------------------------------------------------------------------------

--- a/GTC/deprecated.py
+++ b/GTC/deprecated.py
@@ -153,8 +153,8 @@ def deprecated(*args, **kwargs):
     if args:
         if len(args) > 1:
             raise SyntaxError(
-                '@deprecated{} has too many arguments, '
-                'only the reason (as a string) is allowed'.format(args))
+                f'@deprecated{args} has too many arguments, '
+                f'only the reason (as a string) is allowed')
 
         arg0 = args[0]
 
@@ -166,8 +166,7 @@ def deprecated(*args, **kwargs):
 
         if not (inspect.isfunction(arg0) or inspect.isclass(arg0)):
             raise TypeError(
-                'Cannot use @deprecated on an object of type {!r}'.format(
-                    type(arg0).__name__))
+                f'Cannot use @deprecated on an object of type {type(arg0).__name__!r}')
 
         # Handles @deprecated
         return wrapper(arg0)
@@ -222,11 +221,11 @@ def _prepare_warning(wrapped,
     msg = []
     if prefix:
         msg.append(prefix)
-    msg.append('The {} `{}` is deprecated'.format(kind, wrapped.__name__))
+    msg.append(f'The {kind} `{wrapped.__name__}` is deprecated')
     if deprecated_in:
-        msg.append(' since version {}'.format(deprecated_in))
+        msg.append(f' since version {deprecated_in}')
     if remove_in:
-        msg.append(' and is planned for removal in version {}'.format(remove_in))
+        msg.append(f' and is planned for removal in version {remove_in}')
     msg.append('. ')
     if reason:
         msg.append(reason)
@@ -245,8 +244,8 @@ def _prepare_warning(wrapped,
             tuple(map(int, version.split('.')[:3])) >=
             tuple(map(int, remove_in.split('.')))):
         raise RuntimeError(
-            'Dear GTC developer, you are still using a {} that '
-            'should be removed:\n{}'.format(kind, message)
+            f'Dear GTC developer, you are still using a {kind} that '
+            f'should be removed:\n{message}'
         )
 
     if action == 'module':

--- a/GTC/formatting.py
+++ b/GTC/formatting.py
@@ -119,20 +119,9 @@ class Format(object):
         # This will allow users to see what the equivalent format_spec
         # string would be, instead of them importing and calling
         # create_format() to simply print an uncertain number.
-        spec = '{fill}{align}{sign}{hash}{zero}{width}{grouping}' \
-               '.{digits}{type}{style}'.format(
-                fill=self._fill,
-                align=self._align,
-                sign=self._sign,
-                hash=self._hash,
-                zero=self._zero,
-                width=self._width,
-                grouping=self._grouping,
-                digits=self._digits,
-                type=self._type,
-                style=self._style)
-        return 'Format(format_spec={!r}, df_precision={}, r_precision={})'.format(
-            spec, self._df_precision, self._r_precision)
+        spec = f'{self._fill}{self._align}{self._sign}{self._hash}{self._zero}{self._width}{self._grouping}' \
+               f'.{self._digits}{self._type}{self._style}'
+        return f'Format(format_spec={spec!r}, df_precision={self._df_precision}, r_precision={self._r_precision})'
 
     def _result(self, text):
         """Formats the result.
@@ -145,10 +134,8 @@ class Format(object):
         :return: The `text` formatted.
         :rtype: str
         """
-        fmt = '{fill}{align}{zero}{width}s'.format(
-            fill=self._fill, align=self._align,
-            zero=self._zero, width=self._width)
-        return '{0:{1}}'.format(text, fmt)
+        fmt = f'{self._fill}{self._align}{self._zero}{self._width}s'
+        return f'{text:{fmt}}'
 
     def _value(self, value, precision=None, type=None, sign=None, hash=None):
         """Format a value.
@@ -186,8 +173,7 @@ class Format(object):
             hash = self._hash
 
         if type == 'n':
-            fmt = '%{sign}{hash}.{precision}f'.format(
-                sign=sign, hash=hash, precision=precision)
+            fmt = f'%{sign}{hash}.{precision}f'
             return locale.format_string(fmt, value, grouping=True)
 
         return '{0:{sign}{hash}{grouping}.{precision}{type}}'.format(
@@ -239,7 +225,7 @@ def parse(format_spec):
     """
     match = _format_spec_regex.match(format_spec)
     if not match:
-        raise ValueError('Invalid format specifier {!r}'.format(format_spec))
+        raise ValueError(f'Invalid format specifier {format_spec!r}')
     return match.groupdict()
 
 
@@ -301,7 +287,7 @@ def apply_format(un, fmt):
             StandardUncertainty(re_u.value, im_u.value),
             r, df, un.label)
     else:
-        raise RuntimeError("unexpected type: {!r}".format(un))
+        raise RuntimeError(f"unexpected type: {un!r}")
 
 
 def create_format(obj, digits=None, df_precision=None, r_precision=None,
@@ -400,7 +386,7 @@ def create_format(obj, digits=None, df_precision=None, r_precision=None,
                 'width', 'grouping', 'precision', 'type')
     for key in kwargs:
         if key not in expected:
-            raise ValueError('Unrecognised argument {!r}'.format(key))
+            raise ValueError(f'Unrecognised argument {key!r}')
 
     kwargs['style'] = style
     kwargs['df_precision'] = df_precision
@@ -423,18 +409,18 @@ def create_format(obj, digits=None, df_precision=None, r_precision=None,
 
     if fmt._style not in ('', 'L', 'U'):
         raise ValueError(
-            'Formatting style {!r} is not supported. '
-            'Must be L or U'.format(fmt._style)
+            f'Formatting style {fmt._style!r} is not supported. '
+            f'Must be L or U'
         )
 
     if fmt._digits <= 0:
         raise ValueError(
-            'The number of digits must be > 0 '
-            '[digits={}]'.format(fmt._digits)
+            f'The number of digits must be > 0 '
+            f'[digits={fmt._digits}]'
         )
 
     if fmt._type == 'n' and fmt._grouping:
-        raise ValueError("Cannot specify {!r} with 'n'".format(fmt._grouping))
+        raise ValueError(f"Cannot specify {fmt._grouping!r} with 'n'")
 
     return fmt
 
@@ -475,7 +461,7 @@ def to_string(obj, fmt):
         im_str = _stylize(im_val + i.suffix, fmt)
 
         b1, b2 = _stylize('(', fmt), _stylize(')', fmt)
-        result = '{0}{1}{2}j{3}'.format(b1, re_str, im_str, b2)
+        result = f'{b1}{re_str}{im_str}j{b2}'
         if fmt._type == '%':
             result = move_percent_symbol(result)
         return fmt._result(result)
@@ -485,13 +471,13 @@ def to_string(obj, fmt):
     elif is_ucomplex(obj):
         real, imag = obj.real, obj.imag
     else:
-        raise RuntimeError("unexpected type: {!r}".format(obj))
+        raise RuntimeError(f"unexpected type: {obj!r}")
 
     result = _stylize(_to_string_ureal(real, fmt), fmt)
     if imag is not None:
         imag_str = _to_string_ureal(imag, fmt, sign='+')
         b1, b2 = _stylize('(', fmt), _stylize(')', fmt)
-        result = '{0}{1}{2}j{3}'.format(b1, result, _stylize(imag_str, fmt), b2)
+        result = f'{b1}{result}{_stylize(imag_str, fmt)}j{b2}'
         if fmt._type == '%':
             result = move_percent_symbol(result)
 
@@ -602,13 +588,13 @@ def _stylize(text, fmt):
 
     if fmt._style == 'U':
         if exp_match and exp_number != 0:
-            e = '{}'.format(exp_number)
+            e = f'{exp_number}'
             translated = e.translate(_unicode_superscripts)
-            exponent = '\u00D710{}'.format(translated)
+            exponent = f'\u00D710{translated}'
 
     elif fmt._style == 'L':
         if exp_match and exp_number != 0:
-            exponent = r'\times10^{{{}}}'.format(exp_number)
+            exponent = rf'\times10^{{{exp_number}}}'
 
         replacements = [
             ('(', r'\left('),
@@ -625,7 +611,7 @@ def _stylize(text, fmt):
 
     if exp_match:
         start, end = exp_match.span()
-        text = '{0}{1}{2}'.format(text[:start], exponent, text[end:])
+        text = f'{text[:start]}{exponent}{text[end:]}'
 
     for old, new in replacements:
         text = text.replace(old, new)
@@ -731,12 +717,12 @@ def _to_string_ureal(ureal, fmt, sign=None):
     if _nan_or_inf(x, u):
         x_str = fmt._value(x, sign=sign)
         u_str = fmt._uncertainty(u, type=None)
-        result = '{0}({1})'.format(x_str, u_str)
+        result = f'{x_str}({u_str})'
         # move an exponential term (if it exists) to the end of the string
         exp = _exponent_regex.search(result)
         if exp:
             start, end = exp.span()
-            result = '{0}{1}{2}'.format(result[:start], result[end:], exp.group())
+            result = f'{result[:start]}{result[end:]}{exp.group()}'
         return result
 
     x_rounded, u_rounded = _round_ureal(ureal, fmt)
@@ -762,4 +748,4 @@ def _to_string_ureal(ureal, fmt, sign=None):
     x_str = fmt._value(x_rounded.value, precision=precision, sign=sign,
                        type=x_rounded.type)
 
-    return '{0}({1}){2}'.format(x_str, u_str, x_rounded.suffix)
+    return f'{x_str}({u_str}){x_rounded.suffix}'

--- a/GTC/formatting.py
+++ b/GTC/formatting.py
@@ -176,14 +176,7 @@ class Format(object):
             fmt = f'%{sign}{hash}.{precision}f'
             return locale.format_string(fmt, value, grouping=True)
 
-        return '{0:{sign}{hash}{grouping}.{precision}{type}}'.format(
-            value,
-            sign=sign,
-            hash=hash,
-            grouping=self._grouping,
-            precision=precision,
-            type=type
-        )
+        return f'{value:{sign}{hash}{self._grouping}.{precision}{type}}'
 
     def _uncertainty(self, uncertainty, precision=None, type='f', hash=None):
         """Format an uncertainty.
@@ -371,7 +364,7 @@ def create_format(obj, digits=None, df_precision=None, r_precision=None,
            parentheses and *digits* is equivalent to *precision*.
 
            >>> ur = ureal(3.1415926536, 0)
-           >>> '{:.5f}'.format(ur)
+           >>> f'{ur:.5f}'
            '3.14159'
 
     :rtype: :class:`Format`
@@ -443,7 +436,7 @@ def to_string(obj, fmt):
     """
     def move_percent_symbol(text):
         symbol = r'\%' if fmt._style == 'L' else '%'
-        return '{}{}'.format(text.replace(symbol, ''), symbol)
+        return f"{text.replace(symbol, '')}{symbol}"
 
     if isinstance(obj, (int, float)):
         r = _round(obj, fmt)
@@ -653,7 +646,7 @@ def _round(value, fmt, exponent=None):
         factor = 10. ** exponent
         digits = max(exponent - fmt._u_exponent, 0)
         precision = digits
-        suffix = '{0:.0{1}}'.format(factor, _type)[1:]
+        suffix = f'{factor:.0{_type}}'[1:]
 
     if _type in 'eg%':
         _type = 'f'

--- a/GTC/function.py
+++ b/GTC/function.py
@@ -433,7 +433,7 @@ def nr_get_root(fn,x_min,x_max,epsilon):
     fl = value(f_x)
     
     assert isinstance(f_x,UncertainReal),\
-           "fn() must return an UncertainReal, got: %s" % type(f_x)
+        f"fn() must return an UncertainReal, got: {type(f_x)}"
     
     if abs( fl ) < epsilon:
         return fl,f_x.sensitivity(x)

--- a/GTC/function.py
+++ b/GTC/function.py
@@ -67,7 +67,7 @@ def sum(seq,*args,**kwargs):
         
     else:
         raise RuntimeError(
-            "{!r} is not iterable".format(seq)
+            f"{seq!r} is not iterable"
         )    
 
 #---------------------------------------------------------------------------
@@ -146,24 +146,24 @@ def seq_to_complex(seq):
     """
     if hasattr(seq,'shape'):
         if seq.shape != (2,2):
-            raise RuntimeError("array shape illegal: {}".format(seq))
+            raise RuntimeError(f"array shape illegal: {seq}")
         elif (
             math.fabs( seq[0,0] - seq[1,1] ) > EPSILON
         or  math.fabs( seq[1,0] + seq[0,1] ) > EPSILON ):
-            raise RuntimeError("ill-conditioned sequence: {}".format(seq))
+            raise RuntimeError(f"ill-conditioned sequence: {seq}")
         else:
             seq = list( seq.flat )
             
     elif is_sequence(seq):
         if len(seq) != 4:
-            raise RuntimeError("sequence must have 4 elements: {}".format(seq))
+            raise RuntimeError(f"sequence must have 4 elements: {seq}")
         elif (
             math.fabs( seq[0] - seq[3] ) > EPSILON
         or  math.fabs( seq[1] + seq[2] ) > EPSILON ):
-            raise RuntimeError("ill-conditioned sequence: {}".format(seq))
+            raise RuntimeError(f"ill-conditioned sequence: {seq}")
     
     else:
-        raise RuntimeError("illegal argument: {}".format(seq))
+        raise RuntimeError(f"illegal argument: {seq}")
 
     return complex(seq[0],seq[2])
     
@@ -176,7 +176,7 @@ def _simple_variance(v):
     or  abs(v21) > 1E-15
     ):
         raise RuntimeError(
-            "equal diagonal variance required, got: {}".format(v)
+            f"equal diagonal variance required, got: {v}"
         )
 #---------------------------------------------------------------------------
 def mul2(arg1,arg2,estimated=False):
@@ -277,7 +277,7 @@ def mul2(arg1,arg2,estimated=False):
     for arg in (arg1,arg2):
         if not isinstance(arg,(UncertainReal,UncertainComplex)):
             raise RuntimeError(
-                "uncertain number required, got: {!r}".format( arg )
+                f"uncertain number required, got: {arg!r}"
             )
 
     if isinstance(arg1,UncertainReal):
@@ -288,7 +288,7 @@ def mul2(arg1,arg2,estimated=False):
             return mult_2nd_real_complex(arg1,arg2,estimated)
         else:
             raise RuntimeError(
-                "uncertain number required, got: {!r}".format( arg2 )
+                f"uncertain number required, got: {arg2!r}"
             )
     elif isinstance(arg1,UncertainComplex):
         _simple_variance(arg1.v)
@@ -299,11 +299,11 @@ def mul2(arg1,arg2,estimated=False):
             return mult_2nd_complex_pair(arg1,arg2,estimated)
         else:
             raise RuntimeError(
-                "uncertain number required, got: {!r}".format( arg2 )
+                f"uncertain number required, got: {arg2!r}"
             )
     else:
         raise RuntimeError(
-            "uncertain number required, got: {!r}".format( arg1 )
+            f"uncertain number required, got: {arg1!r}"
         )
  
 #---------------------------------------------------------------------------
@@ -419,7 +419,7 @@ def nr_get_root(fn,x_min,x_max,epsilon):
     """
     if x_max <= x_min:      
         raise RuntimeError(
-            "Invalid search range: {!s}".format((x_min,x_max))
+            f"Invalid search range: {(x_min, x_max)}"
         )
            
     
@@ -447,7 +447,7 @@ def nr_get_root(fn,x_min,x_max,epsilon):
 
     if fl * fu >= 0.0:
         raise RuntimeError(
-           "range does not appear to contain a root: {}".format((fl,fu))
+           f"range does not appear to contain a root: {(fl, fu)}"
         )
 
     if fl > 0.0:

--- a/GTC/function.py
+++ b/GTC/function.py
@@ -238,7 +238,7 @@ def mul2(arg1,arg2,estimated=False):
             >>> y
             ureal(0.0,0.0,inf)
             >>> for cpt in rp.budget(y,trim=0):
-            ... 	print("  {0.label}: {0.u}".format(cpt) )
+            ... 	print(f"  {cpt.label}: {cpt.u}")
             ... 	
               x1: 0.0
               x2: 0.0
@@ -251,7 +251,7 @@ def mul2(arg1,arg2,estimated=False):
             >>> y
             ureal(0.0,1.0,inf)
             >>> for cpt in rp.budget(y,trim=0):
-            ... 	print("  {0.label}: {0.u}".format(cpt) )
+            ... 	print(f"  {cpt.label}: {cpt.u}")
             ... 	
               x1: 0.70710678...
               x2: 0.70710678...

--- a/GTC/json_format.py
+++ b/GTC/json_format.py
@@ -129,7 +129,7 @@ def tagged_to_json(x):
     elif isinstance(x, Complex ):
         return complex_to_json(x)
     else:
-        raise TypeError( "Unrecognised: {}".format( type(x) ) )
+        raise TypeError( f"Unrecognised: {type(x)}" )
  
 #----------------------------------------------------------------------------
 # 

--- a/GTC/lib.py
+++ b/GTC/lib.py
@@ -53,7 +53,7 @@ def _is_uncertain_real_constant(x):
         )
     else:
         raise TypeError(
-            "UncertainReal required: {!r}".format(x)
+            f"UncertainReal required: {x!r}"
         )
 
 #----------------------------------------------------------------------------
@@ -65,7 +65,7 @@ def _is_uncertain_complex_constant(z):
         )
     else:
         raise TypeError(
-            "UncertainComplex required: {!r}".format(z)
+            f"UncertainComplex required: {z!r}"
         )
 
 #-----------------------------------------------------------------------------------------
@@ -208,12 +208,12 @@ class UncertainReal(object):
         """
         if df < 1:
             raise ValueError(
-                "invalid degrees of freedom: {!r}".format(df) 
+                f"invalid degrees of freedom: {df!r}" 
             )
         if u < 0:
             # u == 0 can occur in complex UNs.
             raise ValueError(
-                "invalid uncertainty: {!r}".format(u)
+                f"invalid uncertainty: {u!r}"
             )
                     
         uid = context._context._next_elementary_id()
@@ -342,8 +342,8 @@ class UncertainReal(object):
                     n.label = label
                 elif label != n.label:
                     warnings.warn(
-                        "label `{}` was not changed by `result()`:"
-                        " the new label `{}` has been ignored".format(n.label,label),
+                        f"label `{n.label}` was not changed by `result()`:"
+                        f" the new label `{label}` has been ignored",
                         RuntimeWarning
                     )
                 else:
@@ -361,13 +361,9 @@ class UncertainReal(object):
             df = inf 
         
         if self.label is None:
-            s = "ureal({!r},{!r},{!r})".format( 
-                x,u,df
-            )            
+            s = f"ureal({x!r},{u!r},{df!r})"            
         else:
-            s = "ureal({!r},{!r},{!r}, label={!r})".format( 
-                x,u,df,self.label
-            )                  
+            s = f"ureal({x!r},{u!r},{df!r}, label={self.label!r})"                  
         
         return s
 
@@ -411,7 +407,7 @@ class UncertainReal(object):
                 
             else:
                 raise RuntimeError(
-                    "{!r} is not an elementary or intermediate uncertain number".format(x)
+                    f"{x!r} is not an elementary or intermediate uncertain number"
                 )
              
         elif isinstance(x,UncertainComplex):
@@ -433,7 +429,7 @@ class UncertainReal(object):
             # return self.sensitivity( x.item(0) )
                         
         else:
-            assert False, 'unexpected: {!r}'.format(x)
+            assert False, f'unexpected: {x!r}'
     #------------------------------------------------------------------------
     def u_component(self,x):
         """
@@ -497,7 +493,7 @@ class UncertainReal(object):
                     
                 else:
                     raise TypeError(
-                        "invalid argument {!r}".format(x)
+                        f"invalid argument {x!r}"
                     )
                     
                 result[i] = u_i
@@ -511,7 +507,7 @@ class UncertainReal(object):
             return ComponentOfUncertainty(0.0,0.0,0.0,0.0)
             
         else:
-            assert False, 'unexpected: {!r}'.format(x)
+            assert False, f'unexpected: {x!r}'
 
     #------------------------------------------------------------------------
     def set_correlation(self,r,x):
@@ -530,8 +526,8 @@ class UncertainReal(object):
                     set_correlation_real(self,x,r)
                 else:
                     raise RuntimeError( 
-                        "the argument is not in the same ensemble:" +\
-                        "{!r}, {!r}".format(x._node,self._node)
+                        f"the argument is not in the same ensemble: "
+                        f"{x._node!r}, {self._node!r}"
                     )
         elif isinstance(x,UncertainComplex):
             # TODO: why not implement this? 
@@ -539,13 +535,13 @@ class UncertainReal(object):
             # because either a 2-element or 4-element sequence
             # would work
             raise TypeError(
-                "illegal argument {!r}".format(x)
+                f"illegal argument {x!r}"
             )
             # r_rr = set_correlation_real(self,x.real,r[0])
             # r_ri = set_correlation_real(self,x.imag,r[1])
         else:
             raise TypeError(
-                "argument must be ureal: {!r}".format(x) 
+                f"argument must be ureal: {x!r}" 
             )    
 
     #------------------------------------------------------------------------
@@ -593,7 +589,7 @@ class UncertainReal(object):
                         
         else:
             raise TypeError(
-                "illegal argument {!r}".format(x)
+                f"illegal argument {x!r}"
             )         
             
     #---------------------------------------------------------------------------
@@ -640,7 +636,7 @@ class UncertainReal(object):
             
         else:
             raise TypeError(
-                "illegal argument {!r}".format(arg)
+                f"illegal argument {arg!r}"
             )  
             
     #------------------------------------------------------------------------
@@ -1848,12 +1844,12 @@ def set_correlation_real(x1,x2,r):
         ):
             if ln1 is ln2 and r != 1.0:
                 raise ValueError(
-                    "correlation coefficient '{}' != 1.0".format(r)
+                    f"correlation coefficient '{r}' != 1.0"
                 )
             else:
                 if abs(r) > 1.0:
                     raise ValueError(
-                        "correlation coefficient '|{}|' > 1.0".format(r)
+                        f"correlation coefficient '|{r}|' > 1.0"
                     )
                 else:
                     ln1.correlation[ln2.uid] = r 
@@ -1864,8 +1860,8 @@ def set_correlation_real(x1,x2,r):
             )
     else:
         raise TypeError(
-            "Arguments must be elementary uncertain numbers, \
-            got: {!r} and {!r}".format(x1,x2)
+            f"Arguments must be elementary uncertain numbers, "
+            f"got: {x1!r} and {x2!r}"
         )
 #----------------------------------------------------------------------
 def get_correlation_real(x1,x2):
@@ -2035,7 +2031,7 @@ def welch_satterthwaite(x):
     """    
     if not isinstance(x,UncertainReal):
         raise TypeError(
-            "UncertainReal required, got: '{!r}'".format(x)
+            f"UncertainReal required, got: '{x!r}'"
         )
     
     if x.is_elementary:
@@ -2410,8 +2406,8 @@ class UncertainComplex(object):
         if label is None:
             label_r,label_i = None,None
         else:
-            label_r = "{}_re".format(label)
-            label_i = "{}_im".format(label)
+            label_r = f"{label}_re"
+            label_i = f"{label}_im"
             
         real = UncertainReal._constant(z.real,label_r)
         imag = UncertainReal._constant(z.imag,label_i)
@@ -2450,8 +2446,8 @@ class UncertainComplex(object):
             label_r,label_i = None,None
             
         else:
-            label_r = "{}_re".format(label)
-            label_i = "{}_im".format(label)
+            label_r = f"{label}_re"
+            label_i = f"{label}_im"
             
         # `independent` will be False if `r != 0`
         real = UncertainReal._elementary(z.real,u_r,df,label_r,independent)
@@ -2497,8 +2493,8 @@ class UncertainComplex(object):
             un_re = self.real._intermediate(None)
             un_im = self.imag._intermediate(None) 
         else:
-            label_r = "{}_re".format(label)
-            label_i = "{}_im".format(label)
+            label_r = f"{label}_re"
+            label_i = f"{label}_im"
             
             un_re = self.real._intermediate(label_r)
             un_im = self.imag._intermediate(label_i) 
@@ -2524,20 +2520,12 @@ class UncertainComplex(object):
             df = inf 
 
         if self.label is None:
-            s = ("ucomplex(({0.real:.16g}{0.imag:+.16g}j), "
-                "u=[{1[0]!r},{1[1]!r}], "
-                "r={2!r}, df={3!r}"
-                ")").format( 
-                x,u,r,df
-            )        
+            s = (f"ucomplex(({x.real:.16g}{x.imag:+.16g}j), "
+                 f"u=[{u[0]!r},{u[1]!r}], r={r!r}, df={df!r})")
         else:
-            s = ("ucomplex(({0.real:.16g}{0.imag:+.16g}j), "
-                "u=[{1[0]!r},{1[1]!r}], "
-                "r={2!r}, df={3!r}, "
-                "label={4!r}"
-                ")").format( 
-                x,u,r,df,self.label
-            )        
+            s = (f"ucomplex(({x.real:.16g}{x.imag:+.16g}j), "
+                 f"u=[{u[0]!r},{u[1]!r}], r={r!r}, df={df!r}, "
+                 f"label={self.label!r})")
         
         return s
 
@@ -2587,8 +2575,8 @@ class UncertainComplex(object):
                 
             else:
                 raise RuntimeError(
-                    "An elementary or intermediate " 
-                    + "uncertain number was expected: {!r}".format(x)
+                    f"An elementary or intermediate "
+                    f"uncertain number was expected: {x!r}"
                 )
                 
         elif isinstance(x,UncertainReal):
@@ -2603,14 +2591,14 @@ class UncertainComplex(object):
                 
             else:
                 raise TypeError(
-                    "invalid argument {!r}".format(x)
+                    f"invalid argument {x!r}"
                 )
 
         elif isinstance(x,numbers.Complex):
             return JacobianMatrix(0.0,0.0,0.0,0.0)
 
         else:
-            assert False, 'unexpected: {!r}'.format(x)
+            assert False, f'unexpected: {x!r}'
             
     #------------------------------------------------------------------------
     def u_component(self,x):
@@ -2659,8 +2647,8 @@ class UncertainComplex(object):
                 
             else:
                 raise RuntimeError(
-                    "An elementary or intermediate " 
-                    + "uncertain number was expected: {!r}".format(x)
+                    f"An elementary or intermediate "
+                    f"uncertain number was expected: {x!r}"
                 )
                 
         elif isinstance(x,UncertainReal):
@@ -2677,14 +2665,14 @@ class UncertainComplex(object):
                 
             else:
                 raise TypeError(
-                    "invalid argument {!r}".format(x)
+                    f"invalid argument {x!r}"
                 )
             
         elif isinstance(x,numbers.Complex):
             return ComponentOfUncertainty(0.0,0.0,0.0,0.0)
  
         else:
-            assert False, 'unexpected: {!r}'.format(x) 
+            assert False, f'unexpected: {x!r}' 
             
     #------------------------------------------------------------------------
     def get_correlation(self,arg=None):
@@ -2722,7 +2710,7 @@ class UncertainComplex(object):
             
         else:
             raise TypeError(
-                "illegal second argument {!r}".format(arg)
+                f"illegal second argument {arg!r}"
             )
 
     #------------------------------------------------------------------------
@@ -2738,7 +2726,7 @@ class UncertainComplex(object):
             # because either a 2-element or 4-element sequence
             # would work
             raise TypeError(
-                "illegal argument {!r}".format(arg)
+                f"illegal argument {arg!r}"
             )
             # r_rr = set_correlation_real(self.real,arg,r[0])
             # r_ir = set_correlation_real(self.imag,arg,r[2])
@@ -2746,7 +2734,7 @@ class UncertainComplex(object):
         elif isinstance(arg,UncertainComplex):
             if not( is_sequence(r) and len(r)==4 ):
                 raise TypeError(
-                    "needs a sequence of 4 correlation coefficients: '{!r}'".format(r)
+                    f"needs a sequence of 4 correlation coefficients: '{r!r}'"
                 )
             else:
                 # Trivial case
@@ -2780,7 +2768,7 @@ class UncertainComplex(object):
                         )        
         else:
             raise TypeError(
-                "Illegal argument: {!r}".format(arg)
+                f"Illegal argument: {arg!r}"
             )
                         
     #---------------------------------------------------------------------------
@@ -2817,7 +2805,7 @@ class UncertainComplex(object):
             
         else:
             raise TypeError(
-                "illegal argument {!r}".format(arg)
+                f"illegal argument {arg!r}"
             )
         
     #------------------------------------------------------------------------
@@ -4390,7 +4378,7 @@ def willink_hall(x):
     #
     if not isinstance(x,UncertainComplex):
         raise TypeError(
-            "expected 'UncertainComplex' got: '{!r}'".format(x)
+            f"expected 'UncertainComplex' got: '{x!r}'"
         )
     
     if _is_uncertain_complex_constant(x):
@@ -4703,7 +4691,7 @@ def mult_2nd_real_pair(arg1,arg2,estimated):
         for uid in arg_uids:
             if uid in uids:
                 raise RuntimeError(
-                    "{!r} is a common influence".format(arg)
+                    f"{arg!r} is a common influence"
                 )
         uids.update( arg_uids )
         u_args.append( arg.u )

--- a/GTC/linear_algebra.py
+++ b/GTC/linear_algebra.py
@@ -171,7 +171,7 @@ def uarray(array, label=None, names=None):
             raise TypeError('The elements in the uarray must be a tuple if specifying field names')
 
         if a_len != len(names):
-            raise ValueError('len(array[0]) != len(names) -> {} != {}'.format(a_len, len(names)))
+            raise ValueError(f'len(array[0]) != len(names) -> {a_len} != {len(names)}')
 
         dtype = [(name, type(val)) for name, val in izip(names, array[0])]
 

--- a/GTC/persistence.py
+++ b/GTC/persistence.py
@@ -200,8 +200,8 @@ def _check_xml_kwargs(**kwargs):
     ns = kwargs.get('default_namespace')
     if ns:
         raise ValueError(
-            'Archive uses a custom namespace, '
-            'cannot set default_namespace={!r}'.format(ns)
+            f'Archive uses a custom namespace, '
+            f'cannot set default_namespace={ns!r}'
         )
 
 

--- a/GTC/reporting.py
+++ b/GTC/reporting.py
@@ -485,7 +485,7 @@ def v_bar(cv):
 
     """
     assert len(cv) == 4,\
-           "'%s' a 4-element sequence is needed" % type(cv)
+        f"'{type(cv)}' a 4-element sequence is needed"
 
     return (cv[0] + cv[3]) / 2.0
 

--- a/GTC/reporting.py
+++ b/GTC/reporting.py
@@ -87,7 +87,7 @@ __all__ = (
 )
 
 #--------------------------------------------------------------------------
-uid_str = lambda id: "{0[0]:d}_{0[1]:d}".format(id)
+uid_str = lambda id: f"{id[0]:d}_{id[1]:d}"
 
 #--------------------------------------------------------------------------
 def is_ureal(x):
@@ -179,9 +179,9 @@ def k2_to_dof(k2,p=95):
         
     """
     if k2 <= 0:
-        raise RuntimeError( "invalid k:  {}".format(k2) ) 
+        raise RuntimeError( f"invalid k: {k2}" )
     if p <= 0 or p >= 100:
-        raise RuntimeError( "invalid p: {}".format(p) )
+        raise RuntimeError( f"invalid p: {p}" )
     else:
         p = p / 100.0     
 
@@ -222,7 +222,7 @@ def k2_factor_sq(df=inf,p=95):
         return norm*special.fdtri(2.0,df-1.0,p)
         
     else:
-        raise RuntimeError("invalid df={!r}".format( df ) )
+        raise RuntimeError(f"invalid df={df!r}")
  
 #----------------------------------------------------------------------------
 def k_factor(df=inf,p=95):
@@ -244,7 +244,7 @@ def k_factor(df=inf,p=95):
 
     """
     if p <= 0.0 or p >= 100.0:
-        raise RuntimeError( "invalid p: {}".format( p ) )
+        raise RuntimeError( f"invalid p: {p}" )
     
     p = (1.0 + p/100.0)/2.0
     
@@ -255,7 +255,7 @@ def k_factor(df=inf,p=95):
         # inverse cumulative Student-t distribution
         return special.stdtrit(df,p)
     else:
-        raise RuntimeError( "invalid df: {}".format( df ) )
+        raise RuntimeError( f"invalid df: {df}" )
    
 #----------------------------------------------------------------------------
 def k_to_dof(k,p=95):
@@ -277,9 +277,9 @@ def k_to_dof(k,p=95):
         
     """
     if k <= 0:
-        raise RuntimeError( "invalid k:  {}".format( k ) )  
+        raise RuntimeError( f"invalid k: {k}" )
     if p <= 0 or p >= 100:
-        raise RuntimeError( "invalid p: {}".format( p ) )
+        raise RuntimeError( f"invalid p: {p}" )
     else:
         p = (1.0 + p/100.0)/2.0         
         df = special.stdtridf(p,k) 
@@ -373,7 +373,7 @@ def sensitivity(y,x):
         return y.sensitivity(x)
     else:
         raise RuntimeError(
-            "An uncertain number is expected: {!r}".format(y)
+            f"An uncertain number is expected: {y!r}"
         ) 
         
 #----------------------------------------------------------------------------
@@ -417,7 +417,7 @@ def u_component(y,x):
         return y.u_component(x)
     else:
         raise RuntimeError(
-            "An uncertain number is expected: {!r}".format(y)
+            f"An uncertain number is expected: {y!r}"
         )
 
 #----------------------------------------------------------------------------
@@ -449,7 +449,7 @@ def u_bar(ucpt):
     if is_sequence(ucpt):
         if len(ucpt) != 4:
             raise RuntimeError(
-                "need a 4-element sequence, got: {!r}".format(ucpt)
+                f"need a 4-element sequence, got: {ucpt!r}"
             )
            
         return math.sqrt( reduce(lambda y,x: y + x*x,ucpt,0) / 2 )
@@ -459,7 +459,7 @@ def u_bar(ucpt):
         
     else:
         raise RuntimeError(
-            "need a 4-element sequence or float, got: {!r}".format(ucpt)
+            f"need a 4-element sequence or float, got: {ucpt!r}"
         )
         
 #----------------------------------------------------------------------------
@@ -575,7 +575,7 @@ def components(y,**kwargs):
                     values.append( math.fabs(u_component(y,i.imag)) ) 
                 else:
                     raise RuntimeError(
-                        "unexpected type: '{!r}'".format( i )
+                        f"unexpected type: '{i!r}'"
                     )
         else:
             assert False,"should never occur"
@@ -812,7 +812,7 @@ def budget(y,**kwargs):
             uids = [ n_i.uid for n_i in nodes ]
             labels = [ n_i.label 
                         if n_i.label is not None 
-                            else "{}".format(n_i.uid) 
+                            else f"{n_i.uid}" 
                                 for n_i in nodes ]
             values = [ math.fabs( u ) for u in y._u_components.itervalues() ]
             
@@ -820,7 +820,7 @@ def budget(y,**kwargs):
             uids += [ n_i.uid for n_i in nodes ]
             labels += [ n_i.label 
                         if n_i.label is not None 
-                            else "{}".format(n_i.uid) 
+                            else f"{n_i.uid}" 
                                 for n_i in nodes ]
             values += [ math.fabs( u ) for u in y._d_components.itervalues() ]
             
@@ -836,7 +836,7 @@ def budget(y,**kwargs):
                     
                 uids.append( n_i.uid ) 
                 labels.append( 
-                    n_i.label if n_i.label is not None else "{}".format(n_i.uid) 
+                    n_i.label if n_i.label is not None else f"{n_i.uid}" 
                 )
                 values.append( math.fabs( u_i ) )
             
@@ -859,7 +859,7 @@ def budget(y,**kwargs):
                     values.append( math.fabs(u_component(y,i.imag)) ) 
                 else:
                     raise RuntimeError(
-                        "unexpected type: '{!r}'".format( i )
+                        f"unexpected type: '{i!r}'"
                     )
         else:
             assert False,"should never occur"
@@ -906,9 +906,7 @@ def budget(y,**kwargs):
                         
                         if ir_0.label is None:
                             # No label assigned, report uids
-                            label = "uid({},{})".format(
-                                uid_str(ir_0.uid),uid_str(ii_0.uid)
-                            )
+                            label = f"uid({uid_str(ir_0.uid)},{uid_str(ii_0.uid)})"
                         else:
                             # take the trailing _re off the real label
                             # to label the complex influence
@@ -925,7 +923,7 @@ def budget(y,**kwargs):
                         u=u_bar([ur_0,0,ui_0,0])
                         
                         if ir_0.label is None:
-                            label = "uid({})".format( uid_str(ir_0.uid) )
+                            label = f"uid({uid_str(ir_0.uid)})"
                         else:
                             label = ir_0.label 
                             
@@ -976,9 +974,7 @@ def budget(y,**kwargs):
                         
                         if ir_0.label is None:
                             # No label assigned, report uids
-                            label = "uid({},{})".format(
-                                uid_str(ir_0.uid),uid_str(ii_0.uid)
-                            )
+                            label = f"uid({uid_str(ir_0.uid)},{uid_str(ii_0.uid)})"
                         else:
                             # take the trailing _re off the real label
                             # to label the complex influence
@@ -995,7 +991,7 @@ def budget(y,**kwargs):
                         u=u_bar([ur_0,0,ui_0,0])
                         
                         if ir_0.label is None:
-                            label = "uid({})".format( uid_str(ir_0.uid) )
+                            label = f"uid({uid_str(ir_0.uid)})"
                         else:
                             label = ir_0.label 
                             

--- a/GTC/reporting.py
+++ b/GTC/reporting.py
@@ -764,14 +764,14 @@ def budget(y,**kwargs):
         >>> x3 = ureal(3,0.1,label='x3')
         >>> y = (x1 - x2) / x3
         >>> for i in reporting.budget(y):
-        ...     print("{0}: {1:G}".format(i.label,i.u))
+        ...     print(f"{i.label}: {i.u:G}")
         ... 	
         x1: 0.333333
         x2: 0.166667
         x3: 0.0111111
         
         >>> for i in reporting.budget(y,reverse=False):
-        ... 	print("{0}: {1:G}".format(i.label,i.u))
+        ... 	print(f"{i.label}: {i.u:G}")
         ... 	
         x3: 0.0111111
         x2: 0.166667
@@ -780,7 +780,7 @@ def budget(y,**kwargs):
         >>> y1 = result(x1 + x2,label='y1')
         >>> y2 = result(x2 + x3,label='y2')
         >>> for i in reporting.budget(y1 + y2,intermediate=True):
-        ... 	print("{0}: {1:G}".format(i.label,i.u))
+        ... 	print(f"{i.label}: {i.u:G}")
         ... 
         y1: 1.11803
         y2: 0.509902

--- a/GTC/type_a.py
+++ b/GTC/type_a.py
@@ -460,7 +460,7 @@ def line_fit(x,y,label=None):
     df = N-2
     if df <= 0 or N != len(y):
         raise RuntimeError(
-            "Invalid sequences: len({!r}), len({!r})".format(x,y)
+            f"Invalid sequences: len({x!r}), len({y!r})"
         )
     
     x = value_seq(x)
@@ -493,14 +493,14 @@ def line_fit(x,y,label=None):
         a_,
         siga,
         df=df,
-        label='a_{}'.format(label) if label is not None else None,
+        label=f'a_{label}' if label is not None else None,
         independent=False
     )
     b = ureal(
         b_,
         sigb,
         df=df,
-        label='b_{}'.format(label) if label is not None else None,
+        label=f'b_{label}' if label is not None else None,
         independent=False
     )
     
@@ -577,7 +577,7 @@ def line_fit_wls(x,y,u_y,dof=None,label=None):
     N = len(x)
     if N-2 <= 0 or N != len(y) or N != len(u_y):
         raise RuntimeError(
-            "Invalid sequences: len({!r}), len({!r}), len({!r})".format(x,y,u_y)
+            f"Invalid sequences: len({x!r}), len({y!r}), len({u_y!r})"
         )
         
     x = value_seq(x)
@@ -592,21 +592,21 @@ def line_fit_wls(x,y,u_y,dof=None,label=None):
             df = dof
         else:
             raise RuntimeError( 
-                "{!r} is an invalid degrees of freedom".format(dof) 
+                f"{dof!r} is an invalid degrees of freedom" 
             )
     
     a = ureal(
         a_,
         siga,
         df,
-        label='a_{}'.format(label) if label is not None else None,
+        label=f'a_{label}' if label is not None else None,
         independent=False
     )
     b = ureal(
         b_,
         sigb,
         df,
-        label='b_{}'.format(label) if label is not None else None,
+        label=f'b_{label}' if label is not None else None,
         independent=False
     )    
 
@@ -671,12 +671,12 @@ def line_fit_rwls(x,y,s_y,dof=None,label=None):
             df = dof
         else:
             raise RuntimeError( 
-                "{!r} is an invalid degrees of freedom".format(dof) 
+                f"{dof!r} is an invalid degrees of freedom" 
             )
     
     if N != len(y) or N != len(s_y):
         raise RuntimeError(
-            "Invalid sequences: len({!r}), len({!r}), len({!r})".format(x,y,s_y)
+            f"Invalid sequences: len({x!r}), len({y!r}), len({s_y!r})"
         )
         
     x = value_seq(x)
@@ -692,14 +692,14 @@ def line_fit_rwls(x,y,s_y,dof=None,label=None):
         a_,
         siga,
         df,
-        label='a_{}'.format(label) if label is not None else None,
+        label=f'a_{label}' if label is not None else None,
         independent=False
     )
     b = ureal(
         b_,
         sigb,
         df,
-        label='b_{}'.format(label) if label is not None else None,
+        label=f'b_{label}' if label is not None else None,
         independent=False
     )
     
@@ -770,16 +770,16 @@ def line_fit_wtls(x,y,u_x,u_y,a0_b0=None,r_xy=None,dof=None,label=None):
             df = dof
         else:
             raise RuntimeError( 
-                "{!r} is an invalid degrees of freedom".format(dof) 
+                f"{dof!r} is an invalid degrees of freedom" 
             )
     
     if N != len(y):
         raise RuntimeError(
-            "Invalid sequences: len({!r}), len({!r})".format(x,y)
+            f"Invalid sequences: len({x!r}), len({y!r})"
         )
     if N != len(u_x) or N != len(u_y):
         raise RuntimeError(
-            "Invalid sequences: len({!r}), len({!r})".format(u_x,u_y)
+            f"Invalid sequences: len({u_x!r}), len({u_y!r})"
         )
 
     independent = r_xy is None
@@ -805,14 +805,14 @@ def line_fit_wtls(x,y,u_x,u_y,a0_b0=None,r_xy=None,dof=None,label=None):
         a.x,
         a.u,
         df,
-        label='a_{}'.format(label) if label is not None else None,
+        label=f'a_{label}' if label is not None else None,
         independent=False
     )
     b = ureal(
         b.x,
         b.u,
         df,
-        label='b_{}'.format(label) if label is not None else None,
+        label=f'b_{label}' if label is not None else None,
         independent=False
     )
 
@@ -962,7 +962,7 @@ def estimate(seq,label=None):
     df = len(seq)-1
     if 0 >= df:
         raise RuntimeError(
-            "require: 0 >= len({!r})".format(seq)
+            f"require: 0 >= len({seq!r})"
         )
         
     df = len(seq)-1
@@ -1061,7 +1061,7 @@ def standard_deviation(seq,mu=None):
     N = len(seq)
     if N == 0:
         raise RuntimeError(
-            "empty sequence: {!r}".format(seq)
+            f"empty sequence: {seq!r}"
         )
     
     if mu is None:
@@ -1096,7 +1096,7 @@ def standard_deviation(seq,mu=None):
         
     else:
         raise RuntimeError(
-            "unexpected type for mean value: {!r}".format(mu)
+            f"unexpected type for mean value: {mu!r}"
         )
 
 #-----------------------------------------------------------------------------------------
@@ -1148,7 +1148,7 @@ def standard_uncertainty(seq,mu=None):
     N = len(seq)
     if N == 0:
         raise RuntimeError(
-            "empty sequence: {!r}".format(seq)
+            f"empty sequence: {seq!r}"
         )
 
     ROOT_N = math.sqrt(N)
@@ -1165,7 +1165,7 @@ def standard_uncertainty(seq,mu=None):
         return StandardUncertainty(sd.real/ROOT_N,sd.imag/ROOT_N),r
         
     else:
-        assert False,"unexpected, mu={!r}".format(mu)
+        assert False, f"unexpected, mu={mu!r}"
 
 #-----------------------------------------------------------------------------------------
 def variance_covariance_complex(seq,mu=None):
@@ -1214,7 +1214,7 @@ def variance_covariance_complex(seq,mu=None):
     df = len(seq)-1
     if 0 >= df:
         raise RuntimeError(
-            "require: 0 >= len({!r})".format(seq)
+            f"require: 0 >= len({seq!r})"
         )
     
     zseq = value_seq(seq)
@@ -1279,7 +1279,7 @@ def multi_estimate_real(seq_of_seq,labels=None):
     
     if labels is not None and len(labels) != M:
         raise RuntimeError(
-            "Incorrect number of labels: '{!r}'".format(labels) 
+            f"Incorrect number of labels: '{labels!r}'" 
         ) 
         
     # Calculate the deviations from the mean for each sequence
@@ -1287,7 +1287,7 @@ def multi_estimate_real(seq_of_seq,labels=None):
     dev = []
     for i,seq_i in enumerate(seq_of_seq):
         if len(seq_i) != N:
-            raise RuntimeError( "{:d}th sequence length inconsistent".format(i) )
+            raise RuntimeError( f"{i:d}th sequence length inconsistent" )
 
         mu_i =  value( sum(seq_i) / N )
         means.append( mu_i )
@@ -1385,7 +1385,7 @@ def multi_estimate_complex(seq_of_seq,labels=None):
     
     if labels is not None and len(labels) != M:
         raise RuntimeError( 
-            "Incorrect number of labels: '{!r}'".format(labels) 
+            f"Incorrect number of labels: '{labels!r}'" 
         ) 
 
     # 1. Create a 2M sequence of sequences of real values
@@ -1395,7 +1395,7 @@ def multi_estimate_complex(seq_of_seq,labels=None):
         x.append( [ value(z_i.imag) for z_i in seq_of_seq[i] ] )
         if len(x[-1]) != N:
             raise RuntimeError(
-                "{:d}th sequence length is incorrect".format(i)
+                f"{i:d}th sequence length is incorrect"
             )
 
     TWOM = 2*M
@@ -1519,9 +1519,7 @@ def merge(a,b,TOL=1E-13):
     """
     if abs( value(a) - value(b) ) > TOL:
         raise RuntimeError(
-            "|a - b| = {} > {}: {!r} != {!r}".format(
-                abs( value(a) - value(b) ),TOL,a,b
-            )
+            f"|a - b| = {abs(value(a) - value(b))} > {TOL}: {a!r} != {b!r}"
         )
     else:
         return a + (b - value(b))

--- a/GTC/type_b.py
+++ b/GTC/type_b.py
@@ -161,7 +161,7 @@ def mean(seq,*args,**kwargs):
         
     else:
         raise RuntimeError(
-            "{!r} is not iterable".format(seq)
+            f"{seq!r} is not iterable"
         )
     
     # If `seq` has uncertain number elements then `mu` will be an uncertain number.     
@@ -181,18 +181,12 @@ class LineFit(object):
         self._N = N
         
     def __repr__(self):
-        return """{}(
-  a={!r},
-  b={!r},
-  ssr={},
-  N={}
-)""".format(
-            self.__class__.__name__,
-            self._a_b[0],
-            self._a_b[1],
-            self._ssr,
-            self._N
-        )
+        return f"""{self.__class__.__name__}(
+  a={self._a_b[0]!r},
+  b={self._a_b[1]!r},
+  ssr={self._ssr},
+  N={self._N}
+)"""
 
     @property
     def a_b(self):
@@ -232,19 +226,13 @@ class LineFit(object):
 
     def __str__(self):
         a, b = self.a_b
-        return '''
-  Intercept: {!s}
-  Slope: {!s}
-  Correlation: {:.2G}
-  Sum of the squared residuals: {}
-  Number of points: {}
-'''.format(
-    a,
-    b,
-    a.get_correlation(b),
-    self._ssr,
-    self.N
-)
+        return f'''
+  Intercept: {a}
+  Slope: {b}
+  Correlation: {a.get_correlation(b):.2G}
+  Sum of the squared residuals: {self._ssr}
+  Number of points: {self.N}
+'''
  
 #-----------------------------------------------------------------------------------------
 class LineFitOLS(LineFit):
@@ -400,7 +388,7 @@ def line_fit(x,y):
     N = len(x) 
     if N != len(y):
         raise RuntimeError(
-            "Different sequence lengths: len({!r}) != len({!r})".format(x,y)
+            f"Different sequence lengths: len({x!r}) != len({y!r})"
         )
     
     S_x = sum( x ) 
@@ -484,7 +472,7 @@ def line_fit_wls(x,y,u_y=None):
     """
     if len(x)!= len(y):
         raise RuntimeError(
-            "Different sequence lengths: len({!r}) != len({!r})".format(x,y)
+            f"Different sequence lengths: len({x!r}) != len({y!r})"
         )
 
     if u_y is None:
@@ -964,7 +952,7 @@ def line_fit_wtls(x,y,u_x=None,u_y=None,a_b=None,r_xy=None):
     N = len(x)
     if N != len(y):
         raise RuntimeError(
-            "Different sequence lengths: len({!r}) != len({!r})".format(x,y)
+            f"Different sequence lengths: len({x!r}) != len({y!r})"
         )
 
     if (u_x is not None or u_y is not None):
@@ -978,7 +966,7 @@ def line_fit_wtls(x,y,u_x=None,u_y=None,a_b=None,r_xy=None):
         
         if len(u_x) != N or len(u_y) != N:
             raise RuntimeError(
-                "incompatible sequence lengths: {!r}, {!r}".format(u_x,u_y)
+                f"incompatible sequence lengths: {u_x!r}, {u_y!r}"
             )
 
     for x_i,y_i in izip(x,y):

--- a/GTC/uncertain_array.py
+++ b/GTC/uncertain_array.py
@@ -62,7 +62,7 @@ def _isnan(number):
     elif isinstance(val, Complex):
         return cisnan(val)
     else:
-        raise TypeError('cannot calculate isnan of type {}'.format(type(number)))
+        raise TypeError(f'cannot calculate isnan of type {type(number)}')
 
 
 def _isinf(number):
@@ -72,7 +72,7 @@ def _isinf(number):
     elif isinstance(val, Complex):
         return cisinf(val)
     else:
-        raise TypeError('cannot calculate isinf of type {}'.format(type(number)))
+        raise TypeError(f'cannot calculate isinf of type {type(number)}')
 
 # Note numpy defines its own numeric types, instead of bool, int,
 # float, complex, that have additional attributes. These types are needed by
@@ -144,12 +144,11 @@ class UncertainArray(np.ndarray):
 
         if attr is None:
             raise NotImplementedError(
-                'The {} function has not been implemented'.format(ufunc)
+                f'The {ufunc!r} function has not been implemented'
             )
 
         if kwargs:
-            warnings.warn('**kwargs, {}, are currently not supported'
-                          .format(kwargs), stacklevel=2)
+            warnings.warn(f'**kwargs, {kwargs}, are currently not supported', stacklevel=2)
 
         case = len(inputs)
         if case == 1:
@@ -176,7 +175,7 @@ class UncertainArray(np.ndarray):
                 self._broadcasted_shape = broadcasted.shape
 
         else:
-            assert False, 'Should not occur: __array_ufunc__ received {} inputs'.format(case)
+            assert False, f'Should not occur: __array_ufunc__ received {case} inputs'
 
         return attr(*inputs)
 
@@ -694,7 +693,7 @@ class UncertainArray(np.ndarray):
             if not is_sequence(labels):
                 # Add index notation to the label base
                 labels = [
-                    "{}[{}]".format(labels, i)
+                    f"{labels}[{i}]"
                     for i in xrange(self.size)
                 ]
 

--- a/GTC/uncertain_array.py
+++ b/GTC/uncertain_array.py
@@ -136,7 +136,7 @@ class UncertainArray(np.ndarray):
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         try:
-            attr = getattr(self, '_' + ufunc.__name__)
+            attr = getattr(self, f'_{ufunc.__name__}')
         except AttributeError:
             # Want to raise a NotImplementedError without nested exceptions
             # In Python 3 this could be achieved by "raise Exception('...') from None"
@@ -186,7 +186,7 @@ class UncertainArray(np.ndarray):
         if self.dtype == object:
             # Truncate string from trailing ','
             i = np_array_repr.rfind(',')
-            return np_array_repr[:i] + ')'
+            return f'{np_array_repr[:i]})'
         else:
             return np_array_repr
 

--- a/GTC/vector.py
+++ b/GTC/vector.py
@@ -118,7 +118,7 @@ class Vector(object):
             
         elif len(kwargs) != 0:
             raise RuntimeError(
-                "unidentified keywords '%s'" % kwargs.keys()
+                f"unidentified keywords '{kwargs.keys()}'"
             )
 
 ### There appears to be a large overhead associated with this            

--- a/GTC/vector.py
+++ b/GTC/vector.py
@@ -104,13 +104,13 @@ class Vector(object):
             idx = kwargs['index']
             if getattr(idx,'append',None) is None:
                 raise RuntimeError(
-                    "mutable sequence required, got {!r}".format(type(idx))
+                    f"mutable sequence required, got {type(idx)!r}"
                 )
                 
             val = kwargs['value']
             if getattr(val,'append',None) is None:
                 raise RuntimeError(
-                    "mutable sequence required, got {!r}".format(type(val))
+                    f"mutable sequence required, got {type(val)!r}"
                 )
                 
             self._index = idx

--- a/GTC/xml_format.py
+++ b/GTC/xml_format.py
@@ -102,19 +102,19 @@ def archive_to_xml(archive, indent=None, prefix=None):
     """
     def add_components(parent, name, items):
         # Add Vector components to the parent element
-        elem = SubElement(parent, pre+name)
+        elem = SubElement(parent, f'{pre}{name}')
         for k, v in items():
-            SubElement(elem, pre+'component', uid=_py27uid(k)).text = str(v)
+            SubElement(elem, f'{pre}component', uid=_py27uid(k)).text = str(v)
 
     def add_real(parent, tag, real):
         # Add an ElementaryReal or IntermediateReal to the parent element
         if isinstance(real, ElementaryReal):
-            er = SubElement(parent, pre+'elementaryReal', tag=tag, uid=_py27uid(real.uid))
-            SubElement(er, pre+'value').text = str(real.x)
+            er = SubElement(parent, f'{pre}elementaryReal', tag=tag, uid=_py27uid(real.uid))
+            SubElement(er, f'{pre}value').text = str(real.x)
         elif isinstance(real, IntermediateReal):
-            ir = SubElement(parent, pre+'intermediateReal', tag=tag, uid=_py27uid(real.uid))
-            SubElement(ir, pre+'value').text = str(real.value)
-            SubElement(ir, pre+'label').text = real.label
+            ir = SubElement(parent, f'{pre}intermediateReal', tag=tag, uid=_py27uid(real.uid))
+            SubElement(ir, f'{pre}value').text = str(real.value)
+            SubElement(ir, f'{pre}label').text = real.label
             add_components(ir, 'uComponents', real.u_components.items)
             add_components(ir, 'dComponents', real.d_components.items)
             add_components(ir, 'iComponents', real.i_components.items)
@@ -154,56 +154,56 @@ def archive_to_xml(archive, indent=None, prefix=None):
                 f"An XML namespace prefix cannot contain a colon, "
                 f"got prefix={prefix!r}")
 
-        xmlns = ('xmlns:'+prefix, XMLNS)
-        pre = prefix + ':'
+        xmlns = (f'xmlns:{prefix}', XMLNS)
+        pre = f'{prefix}:'
     else:
         xmlns = ('xmlns', XMLNS)
         pre = ''
 
-    root = Element(pre+'gtcArchive', version='1.5.0')
+    root = Element(f'{pre}gtcArchive', version='1.5.0')
     root.set(*xmlns)
 
-    leaf_nodes = SubElement(root, pre+'leafNodes')
+    leaf_nodes = SubElement(root, f'{pre}leafNodes')
     for uid, ln in leaf_nodes_items():
         assert uid == ln.uid, f'LeafNode(uid={ln.uid}) != {uid}'
-        leaf_node = SubElement(leaf_nodes, pre+'leafNode', uid=_py27uid(uid))
-        SubElement(leaf_node, pre+'u').text = str(ln.u)
-        SubElement(leaf_node, pre+'df').text = normalise_df(ln.df)
-        SubElement(leaf_node, pre+'label').text = ln.label
-        SubElement(leaf_node, pre+'independent').text = 'true' if ln.independent else 'false'
+        leaf_node = SubElement(leaf_nodes, f'{pre}leafNode', uid=_py27uid(uid))
+        SubElement(leaf_node, f'{pre}u').text = str(ln.u)
+        SubElement(leaf_node, f'{pre}df').text = normalise_df(ln.df)
+        SubElement(leaf_node, f'{pre}label').text = ln.label
+        SubElement(leaf_node, f'{pre}independent').text = 'true' if ln.independent else 'false'
         if hasattr(ln, 'complex'):
-            c = SubElement(leaf_node, pre+'complex')
-            SubElement(c, pre+'real', uid=_py27uid(ln.complex[0]))
-            SubElement(c, pre+'imag', uid=_py27uid(ln.complex[1]))
+            c = SubElement(leaf_node, f'{pre}complex')
+            SubElement(c, f'{pre}real', uid=_py27uid(ln.complex[0]))
+            SubElement(c, f'{pre}imag', uid=_py27uid(ln.complex[1]))
         if hasattr(ln, 'correlation'):
-            c = SubElement(leaf_node, pre+'correlations')
+            c = SubElement(leaf_node, f'{pre}correlations')
             for cid, value in ln.correlation:
-                SubElement(c, pre+'correlation', uid=_py27uid(cid)).text = str(value)
+                SubElement(c, f'{pre}correlation', uid=_py27uid(cid)).text = str(value)
         if hasattr(ln, 'ensemble'):
-            e = SubElement(leaf_node, pre+'ensemble')
+            e = SubElement(leaf_node, f'{pre}ensemble')
             for eid in ln.ensemble:
-                SubElement(e, pre+'node', uid=_py27uid(eid))
+                SubElement(e, f'{pre}node', uid=_py27uid(eid))
 
-    tagged_reals = SubElement(root, pre+'taggedReals')
+    tagged_reals = SubElement(root, f'{pre}taggedReals')
     for key, value in tagged_real_items():
         add_real(tagged_reals, key, value)
 
-    untagged_reals = SubElement(root, pre+'untaggedReals')
+    untagged_reals = SubElement(root, f'{pre}untaggedReals')
     for key, value in untagged_real_items():
         add_real(untagged_reals, key, value)
 
-    tagged_complexes = SubElement(root, pre+'taggedComplexes')
+    tagged_complexes = SubElement(root, f'{pre}taggedComplexes')
     for key, value in tagged_complex_items():
-        c = SubElement(tagged_complexes, pre+'complex', tag=key)
-        SubElement(c, pre+'label').text = value.label
+        c = SubElement(tagged_complexes, f'{pre}complex', tag=key)
+        SubElement(c, f'{pre}label').text = value.label
 
-    intermediates = SubElement(root, pre+'intermediates')
+    intermediates = SubElement(root, f'{pre}intermediates')
     for key, value in intermediate_uids_items():
         label, u, df = value
-        inter = SubElement(intermediates, pre+'intermediate', uid=_py27uid(key))
-        SubElement(inter, pre+'label').text = label
-        SubElement(inter, pre+'u').text = str(u)
-        SubElement(inter, pre+'df').text = normalise_df(df)
+        inter = SubElement(intermediates, f'{pre}intermediate', uid=_py27uid(key))
+        SubElement(inter, f'{pre}label').text = label
+        SubElement(inter, f'{pre}u').text = str(u)
+        SubElement(inter, f'{pre}df').text = normalise_df(df)
 
     if indent is not None:
         if indent < 0:

--- a/GTC/xml_format.py
+++ b/GTC/xml_format.py
@@ -77,7 +77,7 @@ def _py27uid(iterable):
 
 def _find(parent, name):
     # Find and return the first matching sub-element
-    return parent.find('{%s}%s' % (XMLNS, name))
+    return parent.find(f'{{{XMLNS}}}{name}')
 
 
 def _float(parent, name):

--- a/GTC/xml_format.py
+++ b/GTC/xml_format.py
@@ -147,12 +147,12 @@ def archive_to_xml(archive, indent=None, prefix=None):
             #   "All other prefixes beginning with the three-letter sequence
             #    x, m, l, in any case combination, are reserved."
             raise ValueError(
-                "An XML namespace prefix should not start with 'xml', "
-                "got prefix={!r}".format(prefix))
+                f"An XML namespace prefix should not start with 'xml', "
+                f"got prefix={prefix!r}")
         if ':' in prefix:
             raise ValueError(
-                "An XML namespace prefix cannot contain a colon, "
-                "got prefix={!r}".format(prefix))
+                f"An XML namespace prefix cannot contain a colon, "
+                f"got prefix={prefix!r}")
 
         xmlns = ('xmlns:'+prefix, XMLNS)
         pre = prefix + ':'
@@ -165,7 +165,7 @@ def archive_to_xml(archive, indent=None, prefix=None):
 
     leaf_nodes = SubElement(root, pre+'leafNodes')
     for uid, ln in leaf_nodes_items():
-        assert uid == ln.uid, 'LeafNode(uid={}) != {}'.format(ln.uid, uid)
+        assert uid == ln.uid, f'LeafNode(uid={ln.uid}) != {uid}'
         leaf_node = SubElement(leaf_nodes, pre+'leafNode', uid=_py27uid(uid))
         SubElement(leaf_node, pre+'u').text = str(ln.u)
         SubElement(leaf_node, pre+'df').text = normalise_df(ln.df)
@@ -207,7 +207,7 @@ def archive_to_xml(archive, indent=None, prefix=None):
 
     if indent is not None:
         if indent < 0:
-            raise ValueError('XML indentation must be >= 0, got {}'.format(indent))
+            raise ValueError(f'XML indentation must be >= 0, got {indent}')
         _py38indent(root, space=' ' * indent)
 
     return root
@@ -223,13 +223,13 @@ def xml_to_archive(element):
     :rtype: :class:`GTC.archive.Archive`
     """
     if not element.tag.endswith('gtcArchive'):
-        raise ValueError('Invalid root tag {!r} for GTC Archive'.format(element.tag))
+        raise ValueError(f'Invalid root tag {element.tag!r} for GTC Archive')
 
     version = element.get('version', 'UNKNOWN')
     if version == '1.5.0':
         return _v150_to_archive(element)
 
-    raise ValueError('Invalid XML Archive version {!r}'.format(version))
+    raise ValueError(f'Invalid XML Archive version {version!r}')
 
 
 def _v150_to_archive(root):
@@ -290,8 +290,8 @@ def _v150_to_archive(root):
     def convert_complex(elem):
         # Returns: tuple(tag:str, Complex)
         t = elem.get('tag')
-        c = Complex(n_re='{}_re'.format(t),
-                    n_im='{}_im'.format(t),
+        c = Complex(n_re=f'{t}_re',
+                    n_im=f'{t}_im',
                     label=_find(elem, 'label').text)
         return t, c
 

--- a/benchmarking/speed.py
+++ b/benchmarking/speed.py
@@ -50,8 +50,8 @@ def fn():
     unc_o = numpy.zeros(N,object)   # The initial values are over-written 
                                     # immediately below
     for i in range(N):
-        name_i = 'unc_i[%s]' %i
-        name_o = 'unc_o[%s]' %i
+        name_i = f'unc_i[{i}]'
+        name_o = f'unc_o[{i}]'
         unc_i[i] = ucomplex(0., [10e-6,0.0])
         unc_o[i] = ucomplex(0., [20e-6,0.0])
         

--- a/benchmarking/speed.py
+++ b/benchmarking/speed.py
@@ -126,11 +126,11 @@ def fn():
 
     _t4 = time.time()
 
-    print('set up time: {}'.format(_t1 - _t0))
-    print('initialisation time: {}'.format(_t2 - _t1))
-    print('build-up time: {}'.format(_t3 - _t2))
-    print('results time: {}'.format(_t4 - _t3))
-    print('total time: {}'.format(_t4 - _t0))
+    print(f'set up time: {_t1 - _t0}')
+    print(f'initialisation time: {_t2 - _t1}')
+    print(f'build-up time: {_t3 - _t2}')
+    print(f'results time: {_t4 - _t3}')
+    print(f'total time: {_t4 - _t0}')
 
 #========================================================
 if __name__ == '__main__':

--- a/examples/GUM_H1.py
+++ b/examples/GUM_H1.py
@@ -33,11 +33,11 @@ tmp2 = l_s * alpha_s * d_theta
 # Final equation for the measurement result
 l = result( l_s + d - (tmp1 + tmp2), label='l')
 
-print( "Measurement result for l={}".format(l) )
+print(f"Measurement result for l={l}")
 
 print("""
 Components of uncertainty in l (nm)
 -----------------------------------""")
 
 for i in reporting.budget(l):
-    print( "  {!s}: {:G}".format(i.label,i.u) )
+    print(f"  {i.label!s}: {i.u:G}")

--- a/examples/GUM_H2.py
+++ b/examples/GUM_H2.py
@@ -18,16 +18,15 @@ R = result( V * cos(phi) / I )
 X = result( V * sin(phi) / I )
 Z = result( V / I )
 
-print('R = {}'.format(R) )
-print('X = {}'.format(X) )
-print('Z = {}'.format(Z) )
-print
-print('Correlation between R and X = {:+.2G}'.format( get_correlation(R,X) ) )
-print('Correlation between R and Z = {:+.2G}'.format( get_correlation(R,Z) ) )
-print('Correlation between X and Z = {:+.2G}'.format( get_correlation(X,Z) ) )
+print(f'R = {R}')
+print(f'X = {X}')
+print(f'Z = {Z}')
+print()
+print(f'Correlation between R and X = {get_correlation(R, X):+.2G}')
+print(f'Correlation between R and Z = {get_correlation(R, Z):+.2G}')
+print(f'Correlation between X and Z = {get_correlation(X, Z):+.2G}')
 
 print("""
 (These are not exactly the same values reported in the GUM.
 There is some numerical round-off error in the GUM's calculations.)
 """)
-

--- a/examples/GUM_H3.py
+++ b/examples/GUM_H3.py
@@ -20,9 +20,9 @@ t_rel = [ t_k - t_0 for t_k in t ]
 # Least-squares regression
 cal = type_a.line_fit(t_rel,b)
 print( cal )
-print
+print()
 
 # Apply correction at 30 C
 b_30 = cal.intercept + cal.slope*(30.0 - t_0)
 
-print("Correction at 30 C: {}".format(b_30))
+print(f"Correction at 30 C: {b_30}")

--- a/examples/GUM_H3_systematic.py
+++ b/examples/GUM_H3_systematic.py
@@ -29,7 +29,7 @@ print
 # Least-squares regression for type-A
 cal_a = ta.line_fit(t_rel,b_sys)
 print( cal_a )
-print
+print()
 
 # Combine results
 intercept = ta.merge(cal_a.intercept,cal_b.intercept)
@@ -37,9 +37,9 @@ slope = ta.merge(cal_a.slope,cal_b.slope)
 
 print( repr(intercept) )
 print( repr(slope) )
-print
+print()
 
 # Apply correction at 30 C
 b_30 = intercept + slope*(30.0 - t_0)
 
-print("Correction at 30 C: {}".format(b_30))
+print(f"Correction at 30 C: {b_30}")

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -522,14 +522,14 @@ class TestPolymorphicMaths(unittest.TestCase):
         # an appropriate library or exception, not numerical accuracy.
         for d in unary_fns:
             self.assertTrue( equivalent(
-                eval("{}({})".format(d[0],d[1])),
-                eval("math.{}({})".format(d[0],d[1]))
+                eval(f"{d[0]}({d[1]})"),
+                eval(f"math.{d[0]}({d[1]})")
             ) )
             self.assertTrue( equivalent_complex(
-                eval("{}({})".format(d[0],d[2])),
-                eval("cmath.{}({})".format(d[0],d[2]))
+                eval(f"{d[0]}({d[2]})"),
+                eval(f"cmath.{d[0]}({d[2]})")
             ) )
-            eval("self.assertRaises(TypeError,{},'s')".format(d[0]))
+            eval(f"self.assertRaises(TypeError,{d[0]},'s')")
             
     def test_special_cases(self):
         """

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -1537,11 +1537,11 @@ class TestLineFitTLS(unittest.TestCase):
         uy = [ 150.00,340.71,553.54,956.76,1649.68 ]
     
         un_x = [
-            ureal(x_i,u_i,label="x_{}".format(i) ) 
+            ureal(x_i,u_i,label=f"x_{i}" ) 
                 for i,x_i,u_i in zip(xrange(len(x)),x,ux)
         ]
         un_y = [
-            ureal(y_i,u_i,label="y_{}".format(i)) 
+            ureal(y_i,u_i,label=f"y_{i}") 
                 for i,y_i,u_i in zip(xrange(len(y)),y,uy)
         ]
         

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -178,31 +178,31 @@ class TestFormatting(unittest.TestCase):
 
         f = Format()
         number = -9.3+123.456789j
-        self.assertEqual(f._value(number), '{:.2f}'.format(number))
+        self.assertEqual(f._value(number), f'{number:.2f}')
         number = 123.456789
         self.assertEqual(f._value(number, precision=4, type='f', sign=' '),
-                         '{: .4f}'.format(number))
+                         f'{number: .4f}')
 
         f = Format(precision=4, sign='+')
         number = 123.456789
-        self.assertEqual(f._value(number), '{:+.4f}'.format(number))
+        self.assertEqual(f._value(number), f'{number:+.4f}')
         number = -9.3+123.456789j
-        self.assertEqual(f._value(number), '{:+.4f}'.format(number))
+        self.assertEqual(f._value(number), f'{number:+.4f}')
 
         f = Format(precision=4, sign='+', width=20, fill='*', align='>')
         number = 123.456789
         self.assertEqual(f._result(f._value(number)),
-                         '{:*>+20.4f}'.format(number))
+                         f'{number:*>+20.4f}')
 
         f = Format(precision=4, sign='+', type='e')
         number = 123.456789
-        self.assertEqual(f._value(number), '{:+.4e}'.format(number))
+        self.assertEqual(f._value(number), f'{number:+.4e}')
         number = -9.3+123.456789j
-        self.assertEqual(f._value(number, type='E'), '{:+.4E}'.format(number))
+        self.assertEqual(f._value(number, type='E'), f'{number:+.4E}')
 
         f = Format(grouping=',', precision=0, type='f')
         number = 123456789
-        self.assertEqual(f._value(number), '{:,.0f}'.format(number))
+        self.assertEqual(f._value(number), f'{number:,.0f}')
 
         f = create_format(1.23)
         self.assertEqual(f._precision, 3)
@@ -284,7 +284,7 @@ class TestFormatting(unittest.TestCase):
         def check(ur, expected):
             # different ways to get the same result
             self.assertEqual(repr(ur), expected)
-            self.assertEqual('{!r}'.format(ur), expected)
+            self.assertEqual(f'{ur!r}', expected)
 
         check(ureal(1.23456789, 0.001),
               'ureal(1.23456789,0.001,inf)')
@@ -305,7 +305,7 @@ class TestFormatting(unittest.TestCase):
         def check(uc, expected):
             # different ways to get the same result
             self.assertEqual(repr(uc), expected)
-            self.assertEqual('{!r}'.format(uc), expected)
+            self.assertEqual(f'{uc!r}', expected)
 
         check(ucomplex(1.23456789+0.12345j, 0.001),
               'ucomplex((1.23456789+0.12345j), u=[0.001,0.001], r=0.0, df=inf)')
@@ -324,12 +324,12 @@ class TestFormatting(unittest.TestCase):
         def check(ur, expected):
             # different ways to get the same result
             self.assertEqual(str(ur), expected)
-            self.assertEqual('{}'.format(ur), expected)
-            self.assertEqual('{!s}'.format(ur), expected)
-            self.assertEqual('{: }'.format(ur), expected)
-            self.assertEqual('{: f}'.format(ur), expected)
-            self.assertEqual('{: .2}'.format(ur), expected)
-            self.assertEqual('{: .2f}'.format(ur), expected)
+            self.assertEqual(f'{ur}', expected)
+            self.assertEqual(f'{ur!s}', expected)
+            self.assertEqual(f'{ur: }', expected)
+            self.assertEqual(f'{ur: f}', expected)
+            self.assertEqual(f'{ur: .2}', expected)
+            self.assertEqual(f'{ur: .2f}', expected)
 
         check(ureal(1.23456789, 1000), ' 0(1000)')
         check(ureal(1.23456789, 100), ' 0(100)')
@@ -354,11 +354,11 @@ class TestFormatting(unittest.TestCase):
         def check(uc, expected):
             # different ways to get the same result
             self.assertEqual(str(uc), expected)
-            self.assertEqual('{}'.format(uc), expected)
-            self.assertEqual('{!s}'.format(uc), expected)
-            self.assertEqual('{:+.2f}'.format(uc), expected)
-            self.assertEqual('{:+.2}'.format(uc), expected)
-            self.assertEqual('{:+f}'.format(uc), expected)
+            self.assertEqual(f'{uc}', expected)
+            self.assertEqual(f'{uc!s}', expected)
+            self.assertEqual(f'{uc:+.2f}', expected)
+            self.assertEqual(f'{uc:+.2}', expected)
+            self.assertEqual(f'{uc:+f}', expected)
 
         check(ucomplex(1.23456789 + 9.87654321j, 1000),
               '(+0(1000)+0(1000)j)')
@@ -397,8 +397,8 @@ class TestFormatting(unittest.TestCase):
     def test_bracket_nan_inf_ureal(self):
         ur = UncertainReal._elementary(inf, inf, inf, None, True)
         self.assertEqual(str(ur), ' inf(inf)')
-        self.assertEqual('{}'.format(ur), ' inf(inf)')
-        self.assertEqual('{!s}'.format(ur), ' inf(inf)')
+        self.assertEqual(f'{ur}', ' inf(inf)')
+        self.assertEqual(f'{ur!s}', ' inf(inf)')
         for t in ['f', 'g', 'e']:
             fmt = create_format(ur, type=t)
             self.assertEqual(to_string(ur, fmt), 'inf(inf)')
@@ -412,8 +412,8 @@ class TestFormatting(unittest.TestCase):
 
         ur = UncertainReal._elementary(inf, nan, inf, None, True)
         self.assertEqual(str(ur), ' inf(nan)')
-        self.assertEqual('{}'.format(ur), ' inf(nan)')
-        self.assertEqual('{!s}'.format(ur), ' inf(nan)')
+        self.assertEqual(f'{ur}', ' inf(nan)')
+        self.assertEqual(f'{ur!s}', ' inf(nan)')
         for t in ['f', 'g', 'e']:
             fmt = create_format(ur, type=t)
             self.assertEqual(to_string(ur, fmt), 'inf(nan)')
@@ -427,8 +427,8 @@ class TestFormatting(unittest.TestCase):
 
         ur = UncertainReal._elementary(-inf, nan, inf, None, True)
         self.assertEqual(str(ur), '-inf(nan)')
-        self.assertEqual('{}'.format(ur), '-inf(nan)')
-        self.assertEqual('{!s}'.format(ur), '-inf(nan)')
+        self.assertEqual(f'{ur}', '-inf(nan)')
+        self.assertEqual(f'{ur!s}', '-inf(nan)')
         for t in ['f', 'g', 'e']:
             fmt = create_format(ur, type=t)
             self.assertEqual(to_string(ur, fmt), '-inf(nan)')
@@ -442,8 +442,8 @@ class TestFormatting(unittest.TestCase):
 
         ur = UncertainReal._elementary(nan, inf, inf, None, True)
         self.assertEqual(str(ur), ' nan(inf)')
-        self.assertEqual('{}'.format(ur), ' nan(inf)')
-        self.assertEqual('{!s}'.format(ur), ' nan(inf)')
+        self.assertEqual(f'{ur}', ' nan(inf)')
+        self.assertEqual(f'{ur!s}', ' nan(inf)')
         for t in ['f', 'g', 'e']:
             fmt = create_format(ur, type=t)
             self.assertEqual(to_string(ur, fmt), 'nan(inf)')
@@ -457,8 +457,8 @@ class TestFormatting(unittest.TestCase):
 
         ur = UncertainReal._elementary(nan, nan, inf, None, True)
         self.assertEqual(str(ur), ' nan(nan)')
-        self.assertEqual('{}'.format(ur), ' nan(nan)')
-        self.assertEqual('{!s}'.format(ur), ' nan(nan)')
+        self.assertEqual(f'{ur}', ' nan(nan)')
+        self.assertEqual(f'{ur!s}', ' nan(nan)')
         for t in ['f', 'g', 'e']:
             fmt = create_format(ur, type=t)
             self.assertEqual(to_string(ur, fmt), 'nan(nan)')
@@ -472,28 +472,28 @@ class TestFormatting(unittest.TestCase):
 
         ur = UncertainReal._elementary(3.141, inf, inf, None, True)
         self.assertEqual(str(ur), ' 3.14(inf)')
-        self.assertEqual('{: F}'.format(ur), ' 3.14(INF)')
-        self.assertEqual('{: .3f}'.format(ur), ' 3.141(inf)')
+        self.assertEqual(f'{ur: F}', ' 3.14(INF)')
+        self.assertEqual(f'{ur: .3f}', ' 3.141(inf)')
 
         ur = UncertainReal._elementary(3.141e8, inf, inf, None, True)
         self.assertEqual(str(ur), ' 314100000.00(inf)')
-        self.assertEqual('{: .1F}'.format(ur), ' 314100000.0(INF)')
-        self.assertEqual('{: .1e}'.format(ur), ' 3.1(inf)e+08')
-        self.assertEqual('{: .4E}'.format(ur), ' 3.1410(INF)E+08')
+        self.assertEqual(f'{ur: .1F}', ' 314100000.0(INF)')
+        self.assertEqual(f'{ur: .1e}', ' 3.1(inf)e+08')
+        self.assertEqual(f'{ur: .4E}', ' 3.1410(INF)E+08')
 
         ur = UncertainReal._elementary(3.141, nan, inf, None, True)
         self.assertEqual(str(ur), ' 3.14(nan)')
-        self.assertEqual('{: F}'.format(ur), ' 3.14(NAN)')
-        self.assertEqual('{: .1F}'.format(ur), ' 3.1(NAN)')
+        self.assertEqual(f'{ur: F}', ' 3.14(NAN)')
+        self.assertEqual(f'{ur: .1F}', ' 3.1(NAN)')
 
         ur = UncertainReal._elementary(nan, 3.141, inf, None, True)
         self.assertEqual(str(ur), ' nan(3.141)')
-        self.assertEqual('{: F}'.format(ur), ' NAN(3.141)')
+        self.assertEqual(f'{ur: F}', ' NAN(3.141)')
 
         ur = UncertainReal._elementary(nan, 3.141e8, inf, None, True)
         self.assertEqual(str(ur), ' nan(314100000)')
-        self.assertEqual('{: E}'.format(ur), ' NAN(3)E+08')
-        self.assertEqual('{: e}'.format(ur), ' nan(3)e+08')
+        self.assertEqual(f'{ur: E}', ' NAN(3)E+08')
+        self.assertEqual(f'{ur: e}', ' nan(3)e+08')
 
     def test_bracket_nan_inf_ucomplex(self):
         uc = UncertainComplex._elementary(
@@ -502,8 +502,8 @@ class TestFormatting(unittest.TestCase):
         )
 
         self.assertEqual(str(uc), '(+inf(inf)+inf(inf)j)')
-        self.assertEqual('{}'.format(uc), '(+inf(inf)+inf(inf)j)')
-        self.assertEqual('{!s}'.format(uc), '(+inf(inf)+inf(inf)j)')
+        self.assertEqual(f'{uc}', '(+inf(inf)+inf(inf)j)')
+        self.assertEqual(f'{uc!s}', '(+inf(inf)+inf(inf)j)')
         for t in ['f', 'g', 'e']:
             fmt = create_format(uc, type=t, sign='+')
             self.assertEqual(to_string(uc, fmt), '(+inf(inf)+inf(inf)j)')
@@ -529,8 +529,8 @@ class TestFormatting(unittest.TestCase):
         )
 
         self.assertEqual(str(uc), '(+nan(inf)-inf(nan)j)')
-        self.assertEqual('{}'.format(uc), '(+nan(inf)-inf(nan)j)')
-        self.assertEqual('{!s}'.format(uc), '(+nan(inf)-inf(nan)j)')
+        self.assertEqual(f'{uc}', '(+nan(inf)-inf(nan)j)')
+        self.assertEqual(f'{uc!s}', '(+nan(inf)-inf(nan)j)')
         for t in ['f', 'g', 'e']:
             fmt = create_format(uc, type=t, sign='+')
             self.assertEqual(to_string(uc, fmt), '(+nan(inf)-inf(nan)j)')
@@ -573,8 +573,8 @@ class TestFormatting(unittest.TestCase):
 
         fmt = create_format(ur, digits=1)
         self.assertEqual(to_string(ur, fmt),   '1.23(1)')
-        self.assertEqual('{:.1}'.format(ur),   '1.23(1)')  # f and B are defaults
-        self.assertEqual('{:.1f}'.format(ur),  '1.23(1)')
+        self.assertEqual(f'{ur:.1}',   '1.23(1)')  # f and B are defaults
+        self.assertEqual(f'{ur:.1f}',  '1.23(1)')
         self.assertEqual(to_string(ur.x, fmt), '1.23')
         self.assertEqual(to_string(ur.u, fmt), '0.01')
         self.assertEqual(to_string(1, fmt),    '1.00')
@@ -583,25 +583,25 @@ class TestFormatting(unittest.TestCase):
 
         fmt = create_format(ur, digits=2)
         self.assertEqual(to_string(ur, fmt),   '1.235(12)')
-        self.assertEqual('{:.2f}'.format(ur),  '1.235(12)')
+        self.assertEqual(f'{ur:.2f}',  '1.235(12)')
         self.assertEqual(to_string(ur.x, fmt), '1.235')
         self.assertEqual(to_string(ur.u, fmt), '0.012')
 
         fmt = create_format(ur, digits=3)
         self.assertEqual(to_string(ur, fmt),   '1.2346(123)')
-        self.assertEqual('{:.3f}'.format(ur),  '1.2346(123)')
+        self.assertEqual(f'{ur:.3f}',  '1.2346(123)')
         self.assertEqual(to_string(ur.x, fmt), '1.2346')
         self.assertEqual(to_string(ur.u, fmt), '0.0123')
 
         fmt = create_format(ur, digits=9)
         self.assertEqual(to_string(ur, fmt),   '1.2345678900(123456789)')
-        self.assertEqual('{:.9f}'.format(ur),  '1.2345678900(123456789)')
+        self.assertEqual(f'{ur:.9f}',  '1.2345678900(123456789)')
         self.assertEqual(to_string(ur.x, fmt), '1.2345678900')
         self.assertEqual(to_string(ur.u, fmt), '0.0123456789')
 
         fmt = create_format(ur, digits=14)
         self.assertEqual(to_string(ur, fmt),   '1.234567890000000(12345678900000)')
-        self.assertEqual('{:.14f}'.format(ur), '1.234567890000000(12345678900000)')
+        self.assertEqual(f'{ur:.14f}', '1.234567890000000(12345678900000)')
         self.assertEqual(to_string(ur.x, fmt), '1.234567890000000')
         self.assertEqual(to_string(ur.u, fmt), '0.012345678900000')
 
@@ -1251,37 +1251,37 @@ class TestFormatting(unittest.TestCase):
         ur = ureal(1.23456789, 0)
 
         fmt = create_format(ur, type='f')
-        self.assertEqual('{:.2f}'.format(ur.x), '1.23')
+        self.assertEqual(f'{ur.x:.2f}', '1.23')
         self.assertEqual(to_string(ur, fmt),    '1.23')
         self.assertEqual(to_string(ur.x, fmt),  '1.23')
         self.assertEqual(to_string(ur.u, fmt),  '0.00')
 
         fmt = create_format(ur, type='f', digits=4)
-        self.assertEqual('{:.4f}'.format(ur.x), '1.2346')
+        self.assertEqual(f'{ur.x:.4f}', '1.2346')
         self.assertEqual(to_string(ur, fmt),    '1.2346')
         self.assertEqual(to_string(ur.x, fmt),  '1.2346')
         self.assertEqual(to_string(ur.u, fmt),  '0.0000')
 
         fmt = create_format(ur, type='g')
-        self.assertEqual('{:.2g}'.format(ur.x), '1.2')
+        self.assertEqual(f'{ur.x:.2g}', '1.2')
         self.assertEqual(to_string(ur, fmt),    '1.2')
         self.assertEqual(to_string(ur.x, fmt),  '1.2')
         self.assertEqual(to_string(ur.u, fmt),  '0')
 
         fmt = create_format(ur, type='g', digits=5)
-        self.assertEqual('{:.5g}'.format(ur.x), '1.2346')
+        self.assertEqual(f'{ur.x:.5g}', '1.2346')
         self.assertEqual(to_string(ur, fmt),    '1.2346')
         self.assertEqual(to_string(ur.x, fmt),  '1.2346')
         self.assertEqual(to_string(ur.u, fmt),  '0')
 
         fmt = create_format(ur, type='E')
-        self.assertEqual('{:.2E}'.format(ur.x), '1.23E+00')
+        self.assertEqual(f'{ur.x:.2E}', '1.23E+00')
         self.assertEqual(to_string(ur, fmt),    '1.23E+00')
         self.assertEqual(to_string(ur.x, fmt),  '1.23E+00')
         self.assertEqual(to_string(ur.u, fmt),  '0.00E+00')
 
         fmt = create_format(ur, type='E', digits=1)
-        self.assertEqual('{:.1E}'.format(ur.x), '1.2E+00')
+        self.assertEqual(f'{ur.x:.1E}', '1.2E+00')
         self.assertEqual(to_string(ur, fmt),    '1.2E+00')
         self.assertEqual(to_string(ur.x, fmt),  '1.2E+00')
         self.assertEqual(to_string(ur.u, fmt),  '0.0E+00')
@@ -1289,37 +1289,37 @@ class TestFormatting(unittest.TestCase):
         uc = ucomplex(12.3456789 + 0.87654321j, 0)
 
         fmt = create_format(uc, type='f')
-        self.assertEqual('{:.2f}'.format(uc.x), '12.35+0.88j')
+        self.assertEqual(f'{uc.x:.2f}', '12.35+0.88j')
         self.assertEqual(to_string(uc, fmt),   '(12.35+0.88j)')
         self.assertEqual(to_string(uc.x, fmt), '(12.35+0.88j)')
         self.assertEqual(to_string(uc.u, fmt), '(0.00+0.00j)')
 
         fmt = create_format(uc, type='f', digits=4)
-        self.assertEqual('{:.4f}'.format(uc.x), '12.3457+0.8765j')
+        self.assertEqual(f'{uc.x:.4f}', '12.3457+0.8765j')
         self.assertEqual(to_string(uc, fmt),   '(12.3457+0.8765j)')
         self.assertEqual(to_string(uc.x, fmt), '(12.3457+0.8765j)')
         self.assertEqual(to_string(uc.u, fmt), '(0.0000+0.0000j)')
 
         fmt = create_format(uc, type='g')
-        self.assertEqual('{:.2g}'.format(uc.x), '12+0.88j')
+        self.assertEqual(f'{uc.x:.2g}', '12+0.88j')
         self.assertEqual(to_string(uc, fmt),   '(12+0.88j)')
         self.assertEqual(to_string(uc.x, fmt), '(12+0.88j)')
         self.assertEqual(to_string(uc.u, fmt), '(0+0j)')
 
         fmt = create_format(uc, type='g', digits=5)
-        self.assertEqual('{:.5g}'.format(uc.x), '12.346+0.87654j')
+        self.assertEqual(f'{uc.x:.5g}', '12.346+0.87654j')
         self.assertEqual(to_string(uc, fmt),   '(12.346+0.87654j)')
         self.assertEqual(to_string(uc.x, fmt), '(12.346+0.87654j)')
         self.assertEqual(to_string(uc.u, fmt), '(0+0j)')
 
         fmt = create_format(uc, type='E')
-        self.assertEqual('{:.2E}'.format(uc.x), '1.23E+01+8.77E-01j')
+        self.assertEqual(f'{uc.x:.2E}', '1.23E+01+8.77E-01j')
         self.assertEqual(to_string(uc, fmt),   '(1.23E+01+8.77E-01j)')
         self.assertEqual(to_string(uc.x, fmt), '(1.23E+01+8.77E-01j)')
         self.assertEqual(to_string(uc.u, fmt), '(0.00E+00+0.00E+00j)')
 
         fmt = create_format(uc, type='e', digits=1)
-        self.assertEqual('{:.1e}'.format(uc.x), '1.2e+01+8.8e-01j')
+        self.assertEqual(f'{uc.x:.1e}', '1.2e+01+8.8e-01j')
         self.assertEqual(to_string(uc, fmt),   '(1.2e+01+8.8e-01j)')
         self.assertEqual(to_string(uc.x, fmt), '(1.2e+01+8.8e-01j)')
         self.assertEqual(to_string(uc.u, fmt), '(0.0e+00+0.0e+00j)')
@@ -1725,29 +1725,29 @@ class TestFormatting(unittest.TestCase):
 
     def test_type_g(self):
         ur = ureal(43.842, 0.0123)
-        self.assertEqual('{:.1g}'.format(ur), '43.84(1)')
+        self.assertEqual(f'{ur:.1g}', '43.84(1)')
 
         ur = ureal(4384.2, 1.23)
-        self.assertEqual('{:.3g}'.format(ur), '4384.20(1.23)')
-        self.assertEqual('{:.1G}'.format(ur), '4.384(1)E+03')
+        self.assertEqual(f'{ur:.3g}', '4384.20(1.23)')
+        self.assertEqual(f'{ur:.1G}', '4.384(1)E+03')
 
         ur = ureal(123456789., 1234.56789)
-        self.assertEqual('{:.4g}'.format(ur), '1.23456789(1235)e+08')
-        self.assertEqual('{:.2G}'.format(ur), '1.234568(12)E+08')
+        self.assertEqual(f'{ur:.4g}', '1.23456789(1235)e+08')
+        self.assertEqual(f'{ur:.2G}', '1.234568(12)E+08')
 
         ur = ureal(7.2524e-8, 5.429e-10)
-        self.assertEqual('{:.2g}'.format(ur), '7.252(54)e-08')
-        self.assertEqual('{:.1G}'.format(ur), '7.25(5)E-08')
+        self.assertEqual(f'{ur:.2g}', '7.252(54)e-08')
+        self.assertEqual(f'{ur:.1G}', '7.25(5)E-08')
 
         ur = ureal(7.2524e4, 5.429e3)
-        self.assertEqual('{:.4G}'.format(ur), '7.2524(5429)E+04')
-        self.assertEqual('{:.1g}'.format(ur), '7.3(5)e+04')
+        self.assertEqual(f'{ur:.4G}', '7.2524(5429)E+04')
+        self.assertEqual(f'{ur:.1g}', '7.3(5)e+04')
 
         uc = ucomplex(12.3456789 + 0.87654321j, 0.31532)
-        self.assertEqual('{:.3G}'.format(uc), '(12.346(315)+0.877(315)j)')
+        self.assertEqual(f'{uc:.3G}', '(12.346(315)+0.877(315)j)')
 
         uc = ucomplex(1.23e6 - 87.e3j, (313e4, 4.75e2))
-        self.assertEqual('{:.2g}'.format(uc), '(1.23000(3.13000)e+06-8.700(48)e+04j)')
+        self.assertEqual(f'{uc:.2g}', '(1.23000(3.13000)e+06-8.700(48)e+04j)')
 
     def test_unicode(self):
         ur = ureal(18.5424, 0.94271)
@@ -1765,11 +1765,11 @@ class TestFormatting(unittest.TestCase):
             self.assertEqual(to_string(ur.u, fmt), '9.4×10⁻¹')
 
         ur = ureal(1.23456789, 0.123456789)
-        self.assertEqual('{:.3eU}'.format(ur), '1.235(123)')
-        self.assertEqual('{:.3EU}'.format(ur * 1e-6), '1.235(123)×10⁻⁶')
-        self.assertEqual('{:.3EU}'.format(ur * 1e12), '1.235(123)×10¹²')
-        self.assertEqual('{:.3eU}'.format(ur * 1e100), '1.235(123)×10¹⁰⁰')
-        self.assertEqual('{:.3EU}'.format(ur * 1e-100), '1.235(123)×10⁻¹⁰⁰')
+        self.assertEqual(f'{ur:.3eU}', '1.235(123)')
+        self.assertEqual(f'{ur * 1e-6:.3EU}', '1.235(123)×10⁻⁶')
+        self.assertEqual(f'{ur * 1e12:.3EU}', '1.235(123)×10¹²')
+        self.assertEqual(f'{ur * 1e100:.3eU}', '1.235(123)×10¹⁰⁰')
+        self.assertEqual(f'{ur * 1e-100:.3EU}', '1.235(123)×10⁻¹⁰⁰')
 
         uc = ucomplex(18.5424+1.2j, 0.94271)
 
@@ -1790,14 +1790,14 @@ class TestFormatting(unittest.TestCase):
         ur = ureal(5.4, 1.2)
 
         fmt = create_format(ur, digits=1, hash='#')
-        self.assertEqual('{:#.1}'.format(ur), '5.(1.)')
+        self.assertEqual(f'{ur:#.1}', '5.(1.)')
         self.assertEqual(to_string(ur, fmt), '5.(1.)')
         self.assertEqual(to_string(ur.x, fmt), '5.')
         self.assertEqual(to_string(ur.u, fmt), '1.')
         self.assertEqual(to_string(3, fmt), '3.')
 
         fmt = create_format(ur, digits=2, hash=True)
-        self.assertEqual('{:#.2}'.format(ur), '5.4(1.2)')
+        self.assertEqual(f'{ur:#.2}', '5.4(1.2)')
         self.assertEqual(to_string(ur, fmt), '5.4(1.2)')
         self.assertEqual(to_string(ur.x, fmt), '5.4')
         self.assertEqual(to_string(ur.u, fmt), '1.2')
@@ -1805,63 +1805,63 @@ class TestFormatting(unittest.TestCase):
 
         uc = ucomplex(5.4 + 7.2j, (1.4, 1.2))
         fmt = create_format(uc, digits=1, hash='#')
-        self.assertEqual('{:#.1}'.format(uc), '(5.(1.)+7.(1.)j)')
+        self.assertEqual(f'{uc:#.1}', '(5.(1.)+7.(1.)j)')
         self.assertEqual(to_string(uc, fmt), '(5.(1.)+7.(1.)j)')
         self.assertEqual(to_string(uc.x, fmt), '(5.+7.j)')
         self.assertEqual(to_string(uc.u, fmt), '(1.+1.j)')
 
         ur = ureal(1, 0.001)
         fmt = create_format(ur, hash=1, digits=1)
-        self.assertEqual('{:#.1}'.format(ur),  '1.000(1)')
+        self.assertEqual(f'{ur:#.1}',  '1.000(1)')
         self.assertEqual(to_string(ur, fmt),   '1.000(1)')
         self.assertEqual(to_string(ur.x, fmt), '1.000')
         self.assertEqual(to_string(ur.u, fmt), '0.001')
 
         ur = ureal(1, 0.1)
         fmt = create_format(ur, hash=True, digits=1)
-        self.assertEqual('{:#.1}'.format(ur),  '1.0(1)')
+        self.assertEqual(f'{ur:#.1}',  '1.0(1)')
         self.assertEqual(to_string(ur, fmt),   '1.0(1)')
         self.assertEqual(to_string(ur.x, fmt), '1.0')
         self.assertEqual(to_string(ur.u, fmt), '0.1')
 
         ur = ureal(1, 1)
         fmt = create_format(ur, hash='#', digits=1)
-        self.assertEqual('{:#.1}'.format(ur),  '1.(1.)')
+        self.assertEqual(f'{ur:#.1}',  '1.(1.)')
         self.assertEqual(to_string(ur, fmt),   '1.(1.)')
         self.assertEqual(to_string(ur.x, fmt), '1.')
         self.assertEqual(to_string(ur.u, fmt), '1.')
 
         ur = ureal(1, 1)
         fmt = create_format(ur, hash=False, digits=1)
-        self.assertEqual('{:.1}'.format(ur),   '1(1)')
+        self.assertEqual(f'{ur:.1}',   '1(1)')
         self.assertEqual(to_string(ur, fmt),   '1(1)')
         self.assertEqual(to_string(ur.x, fmt), '1')
         self.assertEqual(to_string(ur.u, fmt), '1')
 
         ur = ureal(1, 0.9876)
         fmt = create_format(ur, hash='#', digits=1)
-        self.assertEqual('{:#.1}'.format(ur),  '1.(1.)')
+        self.assertEqual(f'{ur:#.1}',  '1.(1.)')
         self.assertEqual(to_string(ur, fmt),   '1.(1.)')
         self.assertEqual(to_string(ur.x, fmt), '1.')
         self.assertEqual(to_string(ur.u, fmt), '1.')
 
         ur = ureal(1, 0.9876)
         fmt = create_format(ur, hash='#', digits=2)
-        self.assertEqual('{:#.2}'.format(ur),  '1.00(99)')
+        self.assertEqual(f'{ur:#.2}',  '1.00(99)')
         self.assertEqual(to_string(ur, fmt),   '1.00(99)')
         self.assertEqual(to_string(ur.x, fmt), '1.00')
         self.assertEqual(to_string(ur.u, fmt), '0.99')
 
         ur = ureal(1, 10)
         fmt = create_format(ur, hash=1, digits=1)
-        self.assertEqual('{:#.1}'.format(ur),  '0.(10.)')
+        self.assertEqual(f'{ur:#.1}',  '0.(10.)')
         self.assertEqual(to_string(ur, fmt),   '0.(10.)')
         self.assertEqual(to_string(ur.x, fmt), '0.')
         self.assertEqual(to_string(ur.u, fmt), '10.')
 
         ur = ureal(1, 1000)
         fmt = create_format(ur, hash=True, digits=1)
-        self.assertEqual('{:#.1}'.format(ur),  '0.(1000.)')
+        self.assertEqual(f'{ur:#.1}',  '0.(1000.)')
         self.assertEqual(to_string(ur, fmt),   '0.(1000.)')
         self.assertEqual(to_string(ur.x, fmt), '0.')
         self.assertEqual(to_string(ur.u, fmt), '1000.')
@@ -1870,9 +1870,9 @@ class TestFormatting(unittest.TestCase):
         fmt = create_format(ur, type='e', hash=True)
         self.assertEqual(to_string(ur, fmt),     '1.23(99)e+04')
         self.assertEqual(to_string(ur.x, fmt),   '1.23e+04')
-        self.assertEqual('{:#.2e}'.format(ur.x), '1.23e+04')
+        self.assertEqual(f'{ur.x:#.2e}', '1.23e+04')
         self.assertEqual(to_string(ur.u, fmt),   '9.9e+03')
-        self.assertEqual('{:#.1e}'.format(ur.u), '9.9e+03')
+        self.assertEqual(f'{ur.u:#.1e}', '9.9e+03')
 
         fmt = create_format(ur, hash=True)
         self.assertEqual(to_string(ur, fmt),   '12300.(9900.)')
@@ -1883,28 +1883,28 @@ class TestFormatting(unittest.TestCase):
         fmt = create_format(ur, type='e', digits=1, hash=True)
         self.assertEqual(to_string(ur, fmt),     '1.(1.)e+01')
         self.assertEqual(to_string(ur.x, fmt),   '1.e+01')
-        self.assertEqual('{:#.0e}'.format(ur.x), '1.e+01')
+        self.assertEqual(f'{ur.x:#.0e}', '1.e+01')
         self.assertEqual(to_string(ur.u, fmt),   '1.e+01')
-        self.assertEqual('{:#.0e}'.format(ur.u), '1.e+01')
+        self.assertEqual(f'{ur.u:#.0e}', '1.e+01')
 
     def test_grouping_field(self):
         ur = ureal(123456789, 123456)
 
         fmt = create_format(ur, digits=6, grouping=',')
-        self.assertEqual('{:,.6}'.format(ur),  '123,456,789(123,456)')
+        self.assertEqual(f'{ur:,.6}',  '123,456,789(123,456)')
         self.assertEqual(to_string(ur, fmt),   '123,456,789(123,456)')
         self.assertEqual(to_string(ur.x, fmt), '123,456,789')
         self.assertEqual(to_string(ur.u, fmt), '123,456')
 
         fmt = create_format(ur, digits=2, grouping=',')
-        self.assertEqual('{:,.2}'.format(ur),  '123,460,000(120,000)')
+        self.assertEqual(f'{ur:,.2}',  '123,460,000(120,000)')
         self.assertEqual(to_string(ur, fmt),   '123,460,000(120,000)')
         self.assertEqual(to_string(ur.x, fmt), '123,460,000')
         self.assertEqual(to_string(ur.u, fmt), '120,000')
 
         if sys.version_info[:2] >= (3, 6):
             fmt = create_format(ur, digits=1, grouping='_')
-            self.assertEqual('{:_.1}'.format(ur),  '123_500_000(100_000)')
+            self.assertEqual(f'{ur:_.1}',  '123_500_000(100_000)')
             self.assertEqual(to_string(ur, fmt),   '123_500_000(100_000)')
             self.assertEqual(to_string(ur.x, fmt), '123_500_000')
             self.assertEqual(to_string(ur.u, fmt), '100_000')
@@ -1912,14 +1912,14 @@ class TestFormatting(unittest.TestCase):
         uc = ucomplex(123456789-987654321j, (123456, 654321))
 
         fmt = create_format(uc, digits=3, grouping=',')
-        self.assertEqual('{:,.3}'.format(uc),  '(123,457,000(123,000)-987,654,000(654,000)j)')
+        self.assertEqual(f'{uc:,.3}',  '(123,457,000(123,000)-987,654,000(654,000)j)')
         self.assertEqual(to_string(uc, fmt),   '(123,457,000(123,000)-987,654,000(654,000)j)')
         self.assertEqual(to_string(uc.x, fmt), '(123,457,000-987,654,000j)')
         self.assertEqual(to_string(uc.u, fmt), '(123,000+654,000j)')
 
         if sys.version_info[:2] >= (3, 6):
             fmt = create_format(uc, digits=4, grouping='_', sign=' ')
-            self.assertEqual('{: _.4}'.format(uc), '( 123_456_800(123_500)-987_654_300(654_300)j)')
+            self.assertEqual(f'{uc: _.4}', '( 123_456_800(123_500)-987_654_300(654_300)j)')
             self.assertEqual(to_string(uc, fmt),   '( 123_456_800(123_500)-987_654_300(654_300)j)')
             self.assertEqual(to_string(uc.x, fmt), '( 123_456_800-987_654_300j)')
             self.assertEqual(to_string(uc.u, fmt), '( 123_500+654_300j)')
@@ -1928,20 +1928,20 @@ class TestFormatting(unittest.TestCase):
     def test_zero_field(self):
         ur = ureal(1.342, 0.0041)
         fmt = create_format(ur, digits=1, zero=True, width=15)
-        self.assertEqual('{:015.1}'.format(ur), '1.342(4)0000000')
+        self.assertEqual(f'{ur:015.1}', '1.342(4)0000000')
         self.assertEqual(to_string(ur, fmt),    '1.342(4)0000000')
         self.assertEqual(to_string(ur.x, fmt),  '1.3420000000000')
         self.assertEqual(to_string(ur.u, fmt),  '0.0040000000000')
 
         fmt = create_format(ur, digits=1, zero=False, width=15)
-        self.assertEqual('{:15.1}'.format(ur),  '1.342(4)       ')
+        self.assertEqual(f'{ur:15.1}',  '1.342(4)       ')
         self.assertEqual(to_string(ur, fmt),    '1.342(4)       ')
         self.assertEqual(to_string(ur.x, fmt),  '1.342          ')
         self.assertEqual(to_string(ur.u, fmt),  '0.004          ')
 
         uc = ucomplex(5.4 + 7.2j, (1.4, 1.2))
         fmt = create_format(uc, digits=2, zero='0', width=24, align='>', sign='+')
-        self.assertEqual('{:>+024.2}'.format(uc), '000(+5.4(1.4)+7.2(1.2)j)')
+        self.assertEqual(f'{uc:>+024.2}', '000(+5.4(1.4)+7.2(1.2)j)')
         self.assertEqual(to_string(uc, fmt),      '000(+5.4(1.4)+7.2(1.2)j)')
         self.assertEqual(to_string(uc.x, fmt),    '0000000000000(+5.4+7.2j)')
         self.assertEqual(to_string(uc.u, fmt),    '0000000000000(+1.4+1.2j)')
@@ -2093,27 +2093,27 @@ class TestFormatting(unittest.TestCase):
 
     def test_latex(self):
         ur = ureal(1.23456789, 0.123456789)
-        self.assertEqual('{:.3eL}'.format(ur), r'1.235\left(123\right)')
-        self.assertEqual('{:.3EL}'.format(ur * 1e-6), r'1.235\left(123\right)\times10^{-6}')
-        self.assertEqual('{:.3EL}'.format(ur * 1e12), r'1.235\left(123\right)\times10^{12}')
-        self.assertEqual('{:.3eL}'.format(ur * 1e100), r'1.235\left(123\right)\times10^{100}')
-        self.assertEqual('{:.3EL}'.format(ur * 1e-100), r'1.235\left(123\right)\times10^{-100}')
+        self.assertEqual(f'{ur:.3eL}', r'1.235\left(123\right)')
+        self.assertEqual(f'{ur * 1e-6:.3EL}', r'1.235\left(123\right)\times10^{-6}')
+        self.assertEqual(f'{ur * 1e12:.3EL}', r'1.235\left(123\right)\times10^{12}')
+        self.assertEqual(f'{ur * 1e100:.3eL}', r'1.235\left(123\right)\times10^{100}')
+        self.assertEqual(f'{ur * 1e-100:.3EL}', r'1.235\left(123\right)\times10^{-100}')
 
         ur = UncertainReal._elementary(3.14159, nan, inf, None, True)
-        self.assertEqual('{:fL}'.format(ur), r'3.14\left(\mathrm{NaN}\right)')
-        self.assertEqual('{:.4fL}'.format(ur), r'3.1416\left(\mathrm{NaN}\right)')
+        self.assertEqual(f'{ur:fL}', r'3.14\left(\mathrm{NaN}\right)')
+        self.assertEqual(f'{ur:.4fL}', r'3.1416\left(\mathrm{NaN}\right)')
 
         ur = UncertainReal._elementary(nan, 3.142, inf, None, True)
-        self.assertEqual('{:L}'.format(ur), r'\mathrm{NaN}\left(3.142\right)')
+        self.assertEqual(f'{ur:L}', r'\mathrm{NaN}\left(3.142\right)')
 
         ur = UncertainReal._elementary(-inf, inf, inf, None, True)
-        self.assertEqual('{:FL}'.format(ur), r'-\infty\left(\infty\right)')
+        self.assertEqual(f'{ur:FL}', r'-\infty\left(\infty\right)')
 
     def test_percent_type(self):
         ur = ureal(0.1548175123, 0.0123456)
 
         fmt = create_format(ur, digits=1, type='%')
-        self.assertEqual('{:.1%}'.format(ur),  '15(1)%')
+        self.assertEqual(f'{ur:.1%}',  '15(1)%')
         self.assertEqual(to_string(ur, fmt),   '15(1)%')
         self.assertEqual(to_string(ur.x, fmt), '15%')
         self.assertEqual(to_string(ur.u, fmt), '1%')
@@ -2128,7 +2128,7 @@ class TestFormatting(unittest.TestCase):
                          'label=None)')
 
         fmt = create_format(ur, digits=3, type='%', style='L')
-        self.assertEqual('{:.3%L}'.format(ur), r'15.48\left(1.23\right)\%')
+        self.assertEqual(f'{ur:.3%L}', r'15.48\left(1.23\right)\%')
         self.assertEqual(to_string(ur, fmt),   r'15.48\left(1.23\right)\%')
         self.assertEqual(to_string(ur.x, fmt), r'15.48\%')
         self.assertEqual(to_string(ur.u, fmt), r'1.23\%')
@@ -2145,7 +2145,7 @@ class TestFormatting(unittest.TestCase):
         ur = ureal(0.1548175123, 0.000123456)
 
         fmt = create_format(ur, type='%', style='L')
-        self.assertEqual('{:%L}'.format(ur),  r'15.482\left(12\right)\%')
+        self.assertEqual(f'{ur:%L}',  r'15.482\left(12\right)\%')
         self.assertEqual(to_string(ur, fmt),  r'15.482\left(12\right)\%')
         self.assertEqual(to_string(ur.x, fmt), r'15.482\%')
         self.assertEqual(to_string(ur.u, fmt), r'0.012\%')
@@ -2162,7 +2162,7 @@ class TestFormatting(unittest.TestCase):
         uc = ucomplex(1548175.123+4321.45j, (123.456, 1.32))
 
         fmt = create_format(uc, digits=1, type='%')
-        self.assertEqual('{:.1%}'.format(uc),  '(154817500(12300)+432100(100)j)%')
+        self.assertEqual(f'{uc:.1%}',  '(154817500(12300)+432100(100)j)%')
         self.assertEqual(to_string(uc, fmt),   '(154817500(12300)+432100(100)j)%')
         self.assertEqual(to_string(uc.x, fmt), '(154817500+432100j)%')
         self.assertEqual(to_string(uc.u, fmt), '(12300+100j)%')
@@ -2180,7 +2180,7 @@ class TestFormatting(unittest.TestCase):
         uc = ucomplex(0.062872513, 0.00023164)
 
         fmt = create_format(uc, digits=3, type='%', style='L')
-        self.assertEqual('{:.3%L}'.format(uc),  r'\left(6.2873\left(232\right)+0.0000\left(232\right)j\right)\%')
+        self.assertEqual(f'{uc:.3%L}',  r'\left(6.2873\left(232\right)+0.0000\left(232\right)j\right)\%')
         self.assertEqual(to_string(uc, fmt),   r'\left(6.2873\left(232\right)+0.0000\left(232\right)j\right)\%')
         self.assertEqual(to_string(uc.x, fmt), r'\left(6.2873+0.0000j\right)\%')
         self.assertEqual(to_string(uc.u, fmt), r'\left(0.0232+0.0232j\right)\%')
@@ -2215,73 +2215,73 @@ class TestFormatting(unittest.TestCase):
         if sys.platform == 'darwin':
             self.assertEqual(to_string(ur, fmt),    '1,23(99)')
             self.assertEqual(to_string(ur.x, fmt),  '1,23')
-            self.assertEqual('{:.3n}'.format(ur.x), '1,23')
+            self.assertEqual(f'{ur.x:.3n}', '1,23')
             self.assertEqual(to_string(ur.u, fmt),  '0,99')
-            self.assertEqual('{:.2n}'.format(ur.u), '0,99')
+            self.assertEqual(f'{ur.u:.2n}', '0,99')
         else:
             self.assertEqual(to_string(ur, fmt),    '1.23(99)')
             self.assertEqual(to_string(ur.x, fmt),  '1.23')
-            self.assertEqual('{:.3n}'.format(ur.x), '1.23')
+            self.assertEqual(f'{ur.x:.3n}', '1.23')
             self.assertEqual(to_string(ur.u, fmt),  '0.99')
-            self.assertEqual('{:.2n}'.format(ur.u), '0.99')
+            self.assertEqual(f'{ur.u:.2n}', '0.99')
 
         ur = ureal(1.2345678987e6, 0.987654321)
         fmt = create_format(ur, type='n', digits=4)
         if sys.platform == 'darwin':
             self.assertEqual(to_string(ur, fmt),     '1234567,8987(9877)')
             self.assertEqual(to_string(ur.x, fmt),   '1234567,8987')
-            self.assertEqual('{:.11n}'.format(ur.x), '1234567,8987')
+            self.assertEqual(f'{ur.x:.11n}', '1234567,8987')
             self.assertEqual(to_string(ur.u, fmt),   '0,9877')
-            self.assertEqual('{:.4n}'.format(ur.u),  '0,9877')
+            self.assertEqual(f'{ur.u:.4n}',  '0,9877')
         elif sys.version_info[:2] == (2, 7) or (sys.platform == 'win32' and
                                                 sys.version_info[:2] == (3, 5)):
             if sys.platform == 'win32':
                 self.assertEqual(to_string(ur, fmt),     '1\x92234\x92567.8987(9877)')
                 self.assertEqual(to_string(ur.x, fmt),   '1\x92234\x92567.8987')
-                self.assertEqual('{:.11n}'.format(ur.x), '1\x92234\x92567.8987')
+                self.assertEqual(f'{ur.x:.11n}', '1\x92234\x92567.8987')
                 self.assertEqual(to_string(ur.u, fmt),   '0.9877')
-                self.assertEqual('{:.4n}'.format(ur.u),  '0.9877')
+                self.assertEqual(f'{ur.u:.4n}',  '0.9877')
             else:
                 self.assertEqual(to_string(ur, fmt),     '1\xe2\x80\x99234\xe2\x80\x99567.8987(9877)')
                 self.assertEqual(to_string(ur.x, fmt),   '1\xe2\x80\x99234\xe2\x80\x99567.8987')
-                self.assertEqual('{:.11n}'.format(ur.x), '1\xe2\x80\x99234\xe2\x80\x99567.8987')
+                self.assertEqual(f'{ur.x:.11n}', '1\xe2\x80\x99234\xe2\x80\x99567.8987')
                 self.assertEqual(to_string(ur.u, fmt),   '0.9877')
-                self.assertEqual('{:.4n}'.format(ur.u),  '0.9877')
+                self.assertEqual(f'{ur.u:.4n}',  '0.9877')
         else:
             self.assertEqual(to_string(ur, fmt),     '1’234’567.8987(9877)')
             self.assertEqual(to_string(ur.x, fmt),   '1’234’567.8987')
-            self.assertEqual('{:.11n}'.format(ur.x), '1’234’567.8987')
+            self.assertEqual(f'{ur.x:.11n}', '1’234’567.8987')
             self.assertEqual(to_string(ur.u, fmt),   '0.9877')
-            self.assertEqual('{:.4n}'.format(ur.u),  '0.9877')
+            self.assertEqual(f'{ur.u:.4n}',  '0.9877')
 
         ur = ureal(12345.6789, 9876.54321)
         fmt = create_format(ur, type='n', digits=8)
         if sys.platform == 'darwin':
             self.assertEqual(to_string(ur, fmt),    '12345,6789(9876,5432)')
             self.assertEqual(to_string(ur.x, fmt),  '12345,6789')
-            self.assertEqual('{:.9n}'.format(ur.x), '12345,6789')
+            self.assertEqual(f'{ur.x:.9n}', '12345,6789')
             self.assertEqual(to_string(ur.u, fmt),  '9876,5432')
-            self.assertEqual('{:.8n}'.format(ur.u), '9876,5432')
+            self.assertEqual(f'{ur.u:.8n}', '9876,5432')
         elif sys.version_info[:2] == (2, 7) or (sys.platform == 'win32' and
                                                 sys.version_info[:2] == (3, 5)):
             if sys.platform == 'win32':
                 self.assertEqual(to_string(ur, fmt),    '12\x92345.6789(9\x92876.5432)')
                 self.assertEqual(to_string(ur.x, fmt),  '12\x92345.6789')
-                self.assertEqual('{:.9n}'.format(ur.x), '12\x92345.6789')
+                self.assertEqual(f'{ur.x:.9n}', '12\x92345.6789')
                 self.assertEqual(to_string(ur.u, fmt),  '9\x92876.5432')
-                self.assertEqual('{:.8n}'.format(ur.u), '9\x92876.5432')
+                self.assertEqual(f'{ur.u:.8n}', '9\x92876.5432')
             else:
                 self.assertEqual(to_string(ur, fmt),    '12\xe2\x80\x99345.6789(9\xe2\x80\x99876.5432)')
                 self.assertEqual(to_string(ur.x, fmt),  '12\xe2\x80\x99345.6789')
-                self.assertEqual('{:.9n}'.format(ur.x), '12\xe2\x80\x99345.6789')
+                self.assertEqual(f'{ur.x:.9n}', '12\xe2\x80\x99345.6789')
                 self.assertEqual(to_string(ur.u, fmt),  '9\xe2\x80\x99876.5432')
-                self.assertEqual('{:.8n}'.format(ur.u), '9\xe2\x80\x99876.5432')
+                self.assertEqual(f'{ur.u:.8n}', '9\xe2\x80\x99876.5432')
         else:
             self.assertEqual(to_string(ur, fmt),    '12’345.6789(9’876.5432)')
             self.assertEqual(to_string(ur.x, fmt),  '12’345.6789')
-            self.assertEqual('{:.9n}'.format(ur.x), '12’345.6789')
+            self.assertEqual(f'{ur.x:.9n}', '12’345.6789')
             self.assertEqual(to_string(ur.u, fmt),  '9’876.5432')
-            self.assertEqual('{:.8n}'.format(ur.u), '9’876.5432')
+            self.assertEqual(f'{ur.u:.8n}', '9’876.5432')
 
     def test_type_n_german(self):
         if sys.platform == 'win32':
@@ -2296,39 +2296,39 @@ class TestFormatting(unittest.TestCase):
         fmt = create_format(ur, type='n')
         self.assertEqual(to_string(ur, fmt),    '1,23(99)')
         self.assertEqual(to_string(ur.x, fmt),  '1,23')
-        self.assertEqual('{:.3n}'.format(ur.x), '1,23')
+        self.assertEqual(f'{ur.x:.3n}', '1,23')
         self.assertEqual(to_string(ur.u, fmt),  '0,99')
-        self.assertEqual('{:.2n}'.format(ur.u), '0,99')
+        self.assertEqual(f'{ur.u:.2n}', '0,99')
 
         ur = ureal(1.2345678987e6, 0.987654321)
         fmt = create_format(ur, type='n', digits=4)
         if sys.platform == 'darwin':
             self.assertEqual(to_string(ur, fmt),     '1234567,8987(9877)')
             self.assertEqual(to_string(ur.x, fmt),   '1234567,8987')
-            self.assertEqual('{:.11n}'.format(ur.x), '1234567,8987')
+            self.assertEqual(f'{ur.x:.11n}', '1234567,8987')
             self.assertEqual(to_string(ur.u, fmt),   '0,9877')
-            self.assertEqual('{:.4n}'.format(ur.u),  '0,9877')
+            self.assertEqual(f'{ur.u:.4n}',  '0,9877')
         else:
             self.assertEqual(to_string(ur, fmt),     '1.234.567,8987(9877)')
             self.assertEqual(to_string(ur.x, fmt),   '1.234.567,8987')
-            self.assertEqual('{:.11n}'.format(ur.x), '1.234.567,8987')
+            self.assertEqual(f'{ur.x:.11n}', '1.234.567,8987')
             self.assertEqual(to_string(ur.u, fmt),   '0,9877')
-            self.assertEqual('{:.4n}'.format(ur.u),  '0,9877')
+            self.assertEqual(f'{ur.u:.4n}',  '0,9877')
 
         ur = ureal(12345.6789, 9876.54321)
         fmt = create_format(ur, type='n', digits=8)
         if sys.platform == 'darwin':
             self.assertEqual(to_string(ur, fmt),    '12345,6789(9876,5432)')
             self.assertEqual(to_string(ur.x, fmt),  '12345,6789')
-            self.assertEqual('{:.9n}'.format(ur.x), '12345,6789')
+            self.assertEqual(f'{ur.x:.9n}', '12345,6789')
             self.assertEqual(to_string(ur.u, fmt),  '9876,5432')
-            self.assertEqual('{:.8n}'.format(ur.u), '9876,5432')
+            self.assertEqual(f'{ur.u:.8n}', '9876,5432')
         else:
             self.assertEqual(to_string(ur, fmt),    '12.345,6789(9.876,5432)')
             self.assertEqual(to_string(ur.x, fmt),  '12.345,6789')
-            self.assertEqual('{:.9n}'.format(ur.x), '12.345,6789')
+            self.assertEqual(f'{ur.x:.9n}', '12.345,6789')
             self.assertEqual(to_string(ur.u, fmt),  '9.876,5432')
-            self.assertEqual('{:.8n}'.format(ur.u), '9.876,5432')
+            self.assertEqual(f'{ur.u:.8n}', '9.876,5432')
 
         if sys.version_info.major > 2:
             # Python 2.7 does not support the # symbol but Python 3.x does
@@ -2336,9 +2336,9 @@ class TestFormatting(unittest.TestCase):
             fmt = create_format(ur, type='n', digits=1, hash=True)
             self.assertEqual(to_string(ur, fmt),     '2,(1,)e+03')
             self.assertEqual(to_string(ur.x, fmt),   '2,e+03')
-            self.assertEqual('{:#.1n}'.format(ur.x), '2,e+03')
+            self.assertEqual(f'{ur.x:#.1n}', '2,e+03')
             self.assertEqual(to_string(ur.u, fmt),   '1,e+03')
-            self.assertEqual('{:#.1n}'.format(ur.u), '1,e+03')
+            self.assertEqual(f'{ur.u:#.1n}', '1,e+03')
 
         ur = ureal(12345, 9876)
         fmt = create_format(ur, type='n', sign=' ', hash=True)
@@ -2347,8 +2347,8 @@ class TestFormatting(unittest.TestCase):
         self.assertEqual(to_string(ur.u, fmt),    ' 9,9e+03')
         if sys.version_info.major > 2:
             # Python 2.7 does not support the # symbol but Python 3.x does
-            self.assertEqual('{: #.3n}'.format(ur.x), ' 1,23e+04')
-            self.assertEqual('{: #.2n}'.format(ur.u), ' 9,9e+03')
+            self.assertEqual(f'{ur.x: #.3n}', ' 1,23e+04')
+            self.assertEqual(f'{ur.u: #.2n}', ' 9,9e+03')
 
     def test_type_n_india(self):
         # this locale is interesting because it can have a different
@@ -2365,39 +2365,39 @@ class TestFormatting(unittest.TestCase):
         fmt = create_format(ur, type='n')
         self.assertEqual(to_string(ur, fmt),    '1.23(99)')
         self.assertEqual(to_string(ur.x, fmt),  '1.23')
-        self.assertEqual('{:.3n}'.format(ur.x), '1.23')
+        self.assertEqual(f'{ur.x:.3n}', '1.23')
         self.assertEqual(to_string(ur.u, fmt),  '0.99')
-        self.assertEqual('{:.2n}'.format(ur.u), '0.99')
+        self.assertEqual(f'{ur.u:.2n}', '0.99')
 
         ur = ureal(1.2345678987e6, 0.987654321)
         fmt = create_format(ur, type='n', digits=4)
         if sys.platform == 'darwin':
             self.assertEqual(to_string(ur, fmt),     '12,345,67.8987(9877)')
             self.assertEqual(to_string(ur.x, fmt),   '12,345,67.8987')
-            self.assertEqual('{:.11n}'.format(ur.x), '12,345,67.8987')
+            self.assertEqual(f'{ur.x:.11n}', '12,345,67.8987')
             self.assertEqual(to_string(ur.u, fmt),   '0.9877')
-            self.assertEqual('{:.4n}'.format(ur.u),  '0.9877')
+            self.assertEqual(f'{ur.u:.4n}',  '0.9877')
         else:
             self.assertEqual(to_string(ur, fmt),     '12,34,567.8987(9877)')
             self.assertEqual(to_string(ur.x, fmt),   '12,34,567.8987')
-            self.assertEqual('{:.11n}'.format(ur.x), '12,34,567.8987')
+            self.assertEqual(f'{ur.x:.11n}', '12,34,567.8987')
             self.assertEqual(to_string(ur.u, fmt),   '0.9877')
-            self.assertEqual('{:.4n}'.format(ur.u),  '0.9877')
+            self.assertEqual(f'{ur.u:.4n}',  '0.9877')
 
         ur = ureal(12345.6789, 9876.54321)
         fmt = create_format(ur, type='n', digits=8)
         if sys.platform == 'darwin':
             self.assertEqual(to_string(ur, fmt),    '123,45.6789(98,76.5432)')
             self.assertEqual(to_string(ur.x, fmt),  '123,45.6789')
-            self.assertEqual('{:.9n}'.format(ur.x), '123,45.6789')
+            self.assertEqual(f'{ur.x:.9n}', '123,45.6789')
             self.assertEqual(to_string(ur.u, fmt),  '98,76.5432')
-            self.assertEqual('{:.8n}'.format(ur.u), '98,76.5432')
+            self.assertEqual(f'{ur.u:.8n}', '98,76.5432')
         else:
             self.assertEqual(to_string(ur, fmt),    '12,345.6789(9,876.5432)')
             self.assertEqual(to_string(ur.x, fmt),  '12,345.6789')
-            self.assertEqual('{:.9n}'.format(ur.x), '12,345.6789')
+            self.assertEqual(f'{ur.x:.9n}', '12,345.6789')
             self.assertEqual(to_string(ur.u, fmt),  '9,876.5432')
-            self.assertEqual('{:.8n}'.format(ur.u), '9,876.5432')
+            self.assertEqual(f'{ur.u:.8n}', '9,876.5432')
 
     def test_type_n_kiwi(self):
         # make sure the native locale for MSL is good
@@ -2413,33 +2413,33 @@ class TestFormatting(unittest.TestCase):
         fmt = create_format(ur, type='n')
         self.assertEqual(to_string(ur, fmt),    '1.23(99)')
         self.assertEqual(to_string(ur.x, fmt),  '1.23')
-        self.assertEqual('{:.3n}'.format(ur.x), '1.23')
+        self.assertEqual(f'{ur.x:.3n}', '1.23')
         self.assertEqual(to_string(ur.u, fmt),  '0.99')
-        self.assertEqual('{:.2n}'.format(ur.u), '0.99')
+        self.assertEqual(f'{ur.u:.2n}', '0.99')
 
         ur = ureal(1.2345678987e6, 0.987654321)
         fmt = create_format(ur, type='n', digits=4)
         self.assertEqual(to_string(ur, fmt),     '1,234,567.8987(9877)')
         self.assertEqual(to_string(ur.x, fmt),   '1,234,567.8987')
-        self.assertEqual('{:.11n}'.format(ur.x), '1,234,567.8987')
+        self.assertEqual(f'{ur.x:.11n}', '1,234,567.8987')
         self.assertEqual(to_string(ur.u, fmt),   '0.9877')
-        self.assertEqual('{:.4n}'.format(ur.u),  '0.9877')
+        self.assertEqual(f'{ur.u:.4n}',  '0.9877')
 
         ur = ureal(12345.6789, 9876.54321)
         fmt = create_format(ur, type='n', digits=8)
         self.assertEqual(to_string(ur, fmt),    '12,345.6789(9,876.5432)')
         self.assertEqual(to_string(ur.x, fmt),  '12,345.6789')
-        self.assertEqual('{:.9n}'.format(ur.x), '12,345.6789')
+        self.assertEqual(f'{ur.x:.9n}', '12,345.6789')
         self.assertEqual(to_string(ur.u, fmt),  '9,876.5432')
-        self.assertEqual('{:.8n}'.format(ur.u), '9,876.5432')
+        self.assertEqual(f'{ur.u:.8n}', '9,876.5432')
 
         ur = ureal(12345.6789, 9876.54321)
         fmt = create_format(ur, type='n', digits=8, sign='+')
         self.assertEqual(to_string(ur, fmt),     '+12,345.6789(9,876.5432)')
         self.assertEqual(to_string(ur.x, fmt),   '+12,345.6789')
-        self.assertEqual('{:+.9n}'.format(ur.x), '+12,345.6789')
+        self.assertEqual(f'{ur.x:+.9n}', '+12,345.6789')
         self.assertEqual(to_string(ur.u, fmt),   '+9,876.5432')
-        self.assertEqual('{:+.8n}'.format(ur.u), '+9,876.5432')
+        self.assertEqual(f'{ur.u:+.8n}', '+9,876.5432')
 
     def test_type_n_afrikaans(self):
         # this locale is interesting because it can have non-ascii characters
@@ -2456,57 +2456,57 @@ class TestFormatting(unittest.TestCase):
         if sys.platform.startswith('linux'):
             self.assertEqual(to_string(ur, fmt),    '1.23(99)')
             self.assertEqual(to_string(ur.x, fmt),  '1.23')
-            self.assertEqual('{:.3n}'.format(ur.x), '1.23')
+            self.assertEqual(f'{ur.x:.3n}', '1.23')
             self.assertEqual(to_string(ur.u, fmt),  '0.99')
-            self.assertEqual('{:.2n}'.format(ur.u), '0.99')
+            self.assertEqual(f'{ur.u:.2n}', '0.99')
         else:
             self.assertEqual(to_string(ur, fmt),    '1,23(99)')
             self.assertEqual(to_string(ur.x, fmt),  '1,23')
-            self.assertEqual('{:.3n}'.format(ur.x), '1,23')
+            self.assertEqual(f'{ur.x:.3n}', '1,23')
             self.assertEqual(to_string(ur.u, fmt),  '0,99')
-            self.assertEqual('{:.2n}'.format(ur.u), '0,99')
+            self.assertEqual(f'{ur.u:.2n}', '0,99')
 
         ur = ureal(1.2345678987e6, 0.987654321)
         fmt = create_format(ur, type='n', digits=4)
         if sys.platform == 'win32':
             self.assertEqual(to_string(ur, fmt),     '1\xa0234\xa0567,8987(9877)')
             self.assertEqual(to_string(ur.x, fmt),   '1\xa0234\xa0567,8987')
-            self.assertEqual('{:.11n}'.format(ur.x), '1\xa0234\xa0567,8987')
+            self.assertEqual(f'{ur.x:.11n}', '1\xa0234\xa0567,8987')
             self.assertEqual(to_string(ur.u, fmt),   '0,9877')
-            self.assertEqual('{:.4n}'.format(ur.u),  '0,9877')
+            self.assertEqual(f'{ur.u:.4n}',  '0,9877')
         elif sys.platform == 'darwin':
             self.assertEqual(to_string(ur, fmt),     '1.234.567,8987(9877)')
             self.assertEqual(to_string(ur.x, fmt),   '1.234.567,8987')
-            self.assertEqual('{:.11n}'.format(ur.x), '1.234.567,8987')
+            self.assertEqual(f'{ur.x:.11n}', '1.234.567,8987')
             self.assertEqual(to_string(ur.u, fmt),   '0,9877')
-            self.assertEqual('{:.4n}'.format(ur.u),  '0,9877')
+            self.assertEqual(f'{ur.u:.4n}',  '0,9877')
         else:
             self.assertEqual(to_string(ur, fmt),     '1,234,567.8987(9877)')
             self.assertEqual(to_string(ur.x, fmt),   '1,234,567.8987')
-            self.assertEqual('{:.11n}'.format(ur.x), '1,234,567.8987')
+            self.assertEqual(f'{ur.x:.11n}', '1,234,567.8987')
             self.assertEqual(to_string(ur.u, fmt),   '0.9877')
-            self.assertEqual('{:.4n}'.format(ur.u),  '0.9877')
+            self.assertEqual(f'{ur.u:.4n}',  '0.9877')
 
         ur = ureal(12345.6789, 9876.54321)
         fmt = create_format(ur, type='n', digits=8)
         if sys.platform == 'win32':
             self.assertEqual(to_string(ur, fmt),    '12\xa0345,6789(9\xa0876,5432)')
             self.assertEqual(to_string(ur.x, fmt),  '12\xa0345,6789')
-            self.assertEqual('{:.9n}'.format(ur.x), '12\xa0345,6789')
+            self.assertEqual(f'{ur.x:.9n}', '12\xa0345,6789')
             self.assertEqual(to_string(ur.u, fmt),  '9\xa0876,5432')
-            self.assertEqual('{:.8n}'.format(ur.u), '9\xa0876,5432')
+            self.assertEqual(f'{ur.u:.8n}', '9\xa0876,5432')
         elif sys.platform == 'darwin':
             self.assertEqual(to_string(ur, fmt),    '12.345,6789(9.876,5432)')
             self.assertEqual(to_string(ur.x, fmt),  '12.345,6789')
-            self.assertEqual('{:.9n}'.format(ur.x), '12.345,6789')
+            self.assertEqual(f'{ur.x:.9n}', '12.345,6789')
             self.assertEqual(to_string(ur.u, fmt),  '9.876,5432')
-            self.assertEqual('{:.8n}'.format(ur.u), '9.876,5432')
+            self.assertEqual(f'{ur.u:.8n}', '9.876,5432')
         else:
             self.assertEqual(to_string(ur, fmt),    '12,345.6789(9,876.5432)')
             self.assertEqual(to_string(ur.x, fmt),  '12,345.6789')
-            self.assertEqual('{:.9n}'.format(ur.x), '12,345.6789')
+            self.assertEqual(f'{ur.x:.9n}', '12,345.6789')
             self.assertEqual(to_string(ur.u, fmt),  '9,876.5432')
-            self.assertEqual('{:.8n}'.format(ur.u), '9,876.5432')
+            self.assertEqual(f'{ur.u:.8n}', '9,876.5432')
 
     def test_to_string_raises(self):
         ur = ureal(1, 1)

--- a/test/test_sensitivity.py
+++ b/test/test_sensitivity.py
@@ -290,18 +290,18 @@ class TestSensitivity(unittest.TestCase):
         y = log10(x4) 
      
         for i,x4_i in enumerate(x4):
-            self.assertEqual('x4[{0}]'.format(i),x4_i.label)
+            self.assertEqual(f'x4[{i}]',x4_i.label)
             
         dy_dx = rp.sensitivity(y,x4)
         uy_x = rp.u_component(y,x4)       
         self.assertTrue( equivalent_sequence(dy_dx,uy_x/x4.u) ) 
   
-        label = [ "x4[{}]".format(i) for i in range(x4.size) ]
+        label = [ f"x4[{i}]" for i in range(x4.size) ]
         x4 = result(x3 ** x1 * x2, label=label)        
         y = log10(x4) 
      
         for i,x4_i in enumerate(x4):
-            self.assertEqual('x4[{0}]'.format(i),x4_i.label)
+            self.assertEqual(f'x4[{i}]',x4_i.label)
  
     def test_intermediate_ucomplex(self):
         """
@@ -337,9 +337,9 @@ class TestSensitivity(unittest.TestCase):
         z = log(z4) 
      
         for i,z4_i in enumerate(z4):
-            self.assertEqual('z4[{0}]'.format(i),z4_i.label)
-            self.assertEqual('z4[{0}]_re'.format(i),z4_i.real.label)
-            self.assertEqual('z4[{0}]_im'.format(i),z4_i.imag.label)
+            self.assertEqual(f'z4[{i}]',z4_i.label)
+            self.assertEqual(f'z4[{i}]_re',z4_i.real.label)
+            self.assertEqual(f'z4[{i}]_im',z4_i.imag.label)
             
         for z_i, z4_i in zip(z,z4):
         
@@ -359,14 +359,14 @@ class TestSensitivity(unittest.TestCase):
                 equivalent(dz_i_dz4_i.ii,uz_i_z4_i.ii/z4_i.imag.u)
             )
 
-        label = [ "z4[{}]".format(i) for i in range(z4.size) ]
+        label = [ f"z4[{i}]" for i in range(z4.size) ]
         z4 = result(z1**z2 * z3, label=label)        
         z = log(z4) 
      
         for i,z4_i in enumerate(z4):
-            self.assertEqual('z4[{0}]'.format(i),z4_i.label)
-            self.assertEqual('z4[{0}]_re'.format(i),z4_i.real.label)
-            self.assertEqual('z4[{0}]_im'.format(i),z4_i.imag.label) 
+            self.assertEqual(f'z4[{i}]',z4_i.label)
+            self.assertEqual(f'z4[{i}]_re',z4_i.real.label)
+            self.assertEqual(f'z4[{i}]_im',z4_i.imag.label) 
 #=====================================================
 if(__name__== '__main__'):
 

--- a/test/test_uncertain_array.py
+++ b/test/test_uncertain_array.py
@@ -2981,7 +2981,7 @@ class TestUncertainArray(unittest.TestCase):
             else:
                 if nc is None:
                     raise AssertionError('The regular matmul FAILED, the custom-written matmul PASSED')
-                self.assertTrue(np.array_equal(nc, uc), 'The arrays are not equal\n{}\n{}'.format(nc, uc))
+                self.assertTrue(np.array_equal(nc, uc), f'The arrays are not equal\n{nc}\n{uc}')
 
     def test_astype(self):
         # make sure that the following is not allowed

--- a/test/test_uncertain_complex.py
+++ b/test/test_uncertain_complex.py
@@ -2549,8 +2549,8 @@ class TestStringRepresentations(unittest.TestCase):
         uc = ucomplex(z, u)
         s = re.search(r'ucomplex\(\((.*)\), u=\[(.*)\], r=(.*), df=(.*)\)', repr(uc))
         
-        self.assertEqual(s.group(1),"{0.real:.16g}{0.imag:+.16g}j".format(z))
-        self.assertEqual(s.group(2),"{0!r},{0!r}".format(u))
+        self.assertEqual(s.group(1),f"{z.real:.16g}{z.imag:+.16g}j")
+        self.assertEqual(s.group(2),f"{u!r},{u!r}")
         self.assertEqual(s.group(3),repr(0.))
         self.assertEqual(s.group(4),"inf")
   

--- a/test/test_uncertain_complex.py
+++ b/test/test_uncertain_complex.py
@@ -67,7 +67,7 @@ def to_std_uncertainty(x):
     elif ( d == 4 ):       
         tmp = numpy.asarray( x, float )
         tmp.shape = ( 2, 2 )
-        assert is_positive_definite( tmp ),"not +ve definite: '%s'"
+        assert is_positive_definite( tmp ), f"not +ve definite: '{tmp}'"
         
         u1 = math.sqrt(tmp[0,0])
         u2 = math.sqrt(tmp[1,1])

--- a/test/test_uncertain_real.py
+++ b/test/test_uncertain_real.py
@@ -872,7 +872,7 @@ class TestUncertainReal(unittest.TestCase):
 
         un = ureal(x,u)
 
-        rep = "ureal({!r},{!r},inf)".format(x,u)
+        rep = f"ureal({x!r},{u!r},inf)"
         self.assertEqual( rep,repr(un) )
         self.assertEqual( x_str,str(un) )
 

--- a/test/testing_tools.py
+++ b/test/testing_tools.py
@@ -71,12 +71,12 @@ def equivalent_matrix(u,m,tol=TOL):
     ):
         return True
     else:
-        print("Differences and tolerance: {} {} {} {} {}".format(
-            abs(u[0,0] - m[0,0])
-        ,   abs(u[1,0] - m[1,0])
-        ,   abs(u[0,1] - m[0,1])
-        ,   abs(u[1,1] - m[1,1])
-        ,   tol))
+        print(f"Differences and tolerance: "
+              f"{abs(u[0,0] - m[0,0])} "
+              f"{abs(u[1,0] - m[1,0])} "
+              f"{abs(u[0,1] - m[0,1])} "
+              f"{abs(u[1,1] - m[1,1])} "
+              f"{tol}")
         raise AssertionError(f"'{u}' <> '{m}'")
 #-----------------------------------------------------
 def show_complex_difference(x,y):
@@ -93,7 +93,7 @@ def equivalent_complex(x,y,tol=TOL):
     if _equivalent(xc.real,yc.real,tol) and _equivalent(xc.imag,yc.imag,tol):
         return True
     else:
-        print("Differences and tolerance: {} {} {}".format(abs(xc.real-yc.real), abs(xc.imag-yc.imag), tol))
+        print(f"Differences and tolerance: {abs(xc.real-yc.real)} {abs(xc.imag-yc.imag)} {tol}")
         raise AssertionError(f"'({x.real:.15G},{x.imag:.15G})' <> '({y.real:.15G},{y.imag:.15G})'")
 
 #-----------------------------------------------------

--- a/test/testing_tools.py
+++ b/test/testing_tools.py
@@ -24,7 +24,7 @@ def equivalent_sequence(u,m,tol=TOL):
     for equivalence
     
     """
-    assert len(u) == len(m), "different lengths: %s and %s" % (u,m)
+    assert len(u) == len(m), f"different lengths: {u} and {m}"
     OK = True
     for u_i,m_i in izip(u,m):
         OK &=  abs(u_i - m_i) < tol       
@@ -32,12 +32,12 @@ def equivalent_sequence(u,m,tol=TOL):
     if OK:
         return True
     else:
-        print("Tolerance = %G" % tol)
+        print(f"Tolerance = {tol:G}")
         print("Differences: ")
         for u_i,m_i in izip(u,m):
             print(abs(u_i - m_i))
             
-        raise AssertionError("'%s' <> '%s' " % (u,m))
+        raise AssertionError(f"'{u}' <> '{m}'")
 
 #-----------------------------------------------------
 def equivalent_matt(m,n,tol=TOL):
@@ -55,12 +55,7 @@ def equivalent_matt(m,n,tol=TOL):
     if (keys == n.keys()):
         for k in keys:
             if abs(m[k] - n[k]) >= tol:
-                print("Values for '%s' differ: abs(%.15G - %.15G) = %.15G" % (
-                        k,
-                        m[k],
-                        n[k],
-                        abs(m[k] - n[k])
-                    ))
+                print(f"Values for '{k}' differ: abs({m[k]:.15G} - {n[k]:.15G}) = {abs(m[k] - n[k]):.15G}")
                 return False
         return True
     else:
@@ -82,13 +77,13 @@ def equivalent_matrix(u,m,tol=TOL):
         ,   abs(u[0,1] - m[0,1])
         ,   abs(u[1,1] - m[1,1])
         ,   tol))
-        raise AssertionError("'%s' <> '%s' " % (u,m))
+        raise AssertionError(f"'{u}' <> '{m}'")
 #-----------------------------------------------------
 def show_complex_difference(x,y):
     """-> a string showing the difference in each component
     """
     z = complex(x)-complex(y)
-    return "Differences: (%.15G,%.15G)" %(z.real, z.imag)
+    return f"Differences: ({z.real:.15G},{z.imag:.15G)}"
     
 #-----------------------------------------------------
 def equivalent_complex(x,y,tol=TOL):
@@ -99,7 +94,7 @@ def equivalent_complex(x,y,tol=TOL):
         return True
     else:
         print("Differences and tolerance: {} {} {}".format(abs(xc.real-yc.real), abs(xc.imag-yc.imag), tol))
-        raise AssertionError("'(%.15G,%.15G)' <> '(%.15G,%.15G)' " % (x.real,x.imag,y.real,y.imag))
+        raise AssertionError(f"'({x.real:.15G},{x.imag:.15G})' <> '({y.real:.15G},{y.imag:.15G})'")
 
 #-----------------------------------------------------
 def _equivalent(x,y,tol):
@@ -116,6 +111,5 @@ def equivalent(x,y,tol=TOL):
     if _equivalent(x,y,tol):
         return True
     else:
-        msg = "Values are not numerically equivalent: abs(%.16G-%.16G) = %.16G with tol= %.16G" % (
-            x,y,abs(x-y),tol)
-        raise AssertionError(msg)
+        raise AssertionError(f"Values are not numerically equivalent: "
+                             f"abs({x:.16G}-{y:.16G}) = {abs(x-y):.16G} with tol= {tol:.16G}")

--- a/test/uarray_matmul.py
+++ b/test/uarray_matmul.py
@@ -156,4 +156,4 @@ def run():
         else:
             if nc is None:
                 raise AssertionError('The regular @ FAILED, the custom-written @ PASSED')
-            assert np.array_equal(nc, uc), 'The arrays are not equal\n{}\n{}'.format(nc, uc)
+            assert np.array_equal(nc, uc), f'The arrays are not equal\n{nc}\n{uc}'


### PR DESCRIPTION
Three different from _X_ to f-string conversions were performed
1. `%` style, e.g., `'hello %s' % 'world'` (changes made manually, ~10 occurrences)
2. things like `string_variable+'some text'` (changes made manually, ~25 occurrences)
3. `.format()` style (changes made automatically using [ruff](https://github.com/astral-sh/ruff), reviewed each change manually, 443 occurrences)

The `ruff` command that I used to perform the lint was
```
> ruff check --select UP032 --fix
Found 443 errors (443 fixed, 0 remaining).
```
The UP032 [rule](https://docs.astral.sh/ruff/rules/#pyupgrade-up) comes from [pyupgrade](https://github.com/asottile/pyupgrade).

`ruff` did a great job and incredibly fast! I didn't find any errors, but I did manually tweak a couple of the changes based on personal preference.