### PR TITLE
Restrict numpy version to be <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def fetch_init(key):
 
 
 install_requires = [
-    'numpy>=1.13.0',  # >=1.13 to override __array_ufunc__ in UncertainArray
+    'numpy>=1.13.0,<2.0',  # >=1.13 to override __array_ufunc__ in UncertainArray
     'scipy'
 ]
 tests_require = [


### PR DESCRIPTION
9 hours ago (from this commit) numpy 2.0 was released.

While we fix GTC 2.0 to support numpy 2.0, this is a temporary workaround.

@BlairDHall Do you agree that this commit should also be ported to the 1.x branch and a new release of GTC 1.5.1 be made?