### PR TITLE
bump to version 2.0.0.dev0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,15 @@ Archival copies of GTC
 
 In addition to the github repository, each release of GTC is archived automatically in Zenodo. The most recent release is always  at (https://doi.org/10.5281/zenodo.3982925) and previous releases can be accessed from that point. Archived releases are a snapshot of project files belonging to a release without additional information about version history.
 
+Version 2.0.0 (in development)
+==============================
+
+
+Version 1.5.1 (2024-06-24)
+==========================
+
+    * Add support for numpy version 2.0
+
 Version 1.5.0 (2024-02-27)
 ==========================
 

--- a/GTC/__init__.py
+++ b/GTC/__init__.py
@@ -111,7 +111,7 @@ if sys.version_info[:2] < (3, 8):
     )
     del warnings
 #----------------------------------------------------------------------------
-version = "1.5.1.dev0"
+version = "2.0.0.dev0"
 
 copyright = """Copyright (c) 2024, \
 Measurement Standards Laboratory of New Zealand"""


### PR DESCRIPTION
v1.5.1 was just released. This PR updates `develop` with the appropriate version info.

I will create a separate PR to bring the numpy 2.0 patch into `develop` once this PR is merged.