### PR TITLE
use new-class style by default

### DIFF
--- a/GTC/archive.py
+++ b/GTC/archive.py
@@ -29,7 +29,7 @@ __all__ = (
 # When an archive is prepared for storage, uncertain number  
 # objects are converted into simple representations
 #
-class LeafNode(object):
+class LeafNode:
     def __init__(self,node):
         
         self.uid = node.uid
@@ -56,12 +56,12 @@ class LeafNode(object):
             # `ensemble` is a set in the Leaf node
             self.ensemble = frozenset( node.ensemble )
         
-class ElementaryReal(object):
+class ElementaryReal:
     def __init__(self,x,uid):
         self.x = x
         self.uid = uid
 
-class IntermediateReal(object):
+class IntermediateReal:
     def __init__(self,value,u_components,d_components,i_components,label,uid):
         self.value = value
         self.u_components = u_components    
@@ -70,7 +70,7 @@ class IntermediateReal(object):
         self.label = label
         self.uid = uid
     
-class Complex(object):
+class Complex:
     def __init__(self,n_re,n_im,label):
         self.n_re = n_re
         self.n_im = n_im
@@ -99,7 +99,7 @@ class Complex(object):
 # the specific uncertain numbers that were saved initially. Finally, 
 # these uncertain numbers may be restored (on demand).
 # """
-class Archive(object):
+class Archive:
     """
     An :class:`Archive` helps to store and retrieve uncertain numbers,
     so that they can be used in later calculations. 

--- a/GTC/context.py
+++ b/GTC/context.py
@@ -20,7 +20,7 @@ __all__ = (
 )
 
 #----------------------------------------------------------------------------
-class Context(object):
+class Context:
 
     """
     A ``Context`` object the creation of uncertain numbers 

--- a/GTC/formatting.py
+++ b/GTC/formatting.py
@@ -71,7 +71,7 @@ _unicode_superscripts = {
 _Rounded = namedtuple('Rounded', 'value precision type exponent suffix')
 
 
-class Format(object):
+class Format:
     """Format specification for an uncertain number.
 
     Do not instantiate this class directly. The proper way to create a

--- a/GTC/lib.py
+++ b/GTC/lib.py
@@ -105,7 +105,7 @@ def value_seq(x):
     return rtn    
     
 #----------------------------------------------------------------------------
-class UncertainReal(object):
+class UncertainReal:
     
     """
     An :class:`UncertainReal` holds information about the measured 
@@ -2310,7 +2310,7 @@ def z_to_seq( z ):
     return (re, -im, im, re)
 
 #---------------------------------------------------------------------------
-class UncertainComplex(object):
+class UncertainComplex:
     
     """
     An :class:`UncertainComplex` holds information about the measured
@@ -4295,7 +4295,7 @@ def _covariance_submatrix(u_re,u_im):
     return v_rr, v_ri, v_ii
 
 #---------------------------------------------------------------------------
-class _EnsembleComponents(object):
+class _EnsembleComponents:
     
     """
     Worker class for the willink_hall function 

--- a/GTC/nodes.py
+++ b/GTC/nodes.py
@@ -9,7 +9,7 @@ __all__ = (
 )
 
 #----------------------------------------------------------------------------
-class Node(object):
+class Node:
     
     """
     A `Node` holds information about an intermediate uncertain real number
@@ -44,7 +44,7 @@ class Leaf(Node):
     ]
     
     def __init__(self,uid,label,u,df,independent=True):
-        Node.__init__(self,uid,label,u,df)
+        super().__init__(uid,label,u,df)
     
         self.independent = independent
         if not independent:

--- a/GTC/nodes.py
+++ b/GTC/nodes.py
@@ -44,8 +44,8 @@ class Leaf(Node):
     ]
     
     def __init__(self,uid,label,u,df,independent=True):
-        super().__init__(uid,label,u,df)
-    
+        Node.__init__(self,uid,label,u,df)
+
         self.independent = independent
         if not independent:
             # Provide objects for these attributes.

--- a/GTC/type_a.py
+++ b/GTC/type_a.py
@@ -125,8 +125,8 @@ class LineFitOLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        super().__init__(a,b,ssr,N)
-            
+        LineFit.__init__(self,a,b,ssr,N)
+
     def __str__(self):
         header = '''
 Ordinary Least-Squares Results:
@@ -235,7 +235,7 @@ class LineFitRWLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        super().__init__(a,b,ssr,N)
+        LineFit.__init__(self,a,b,ssr,N)
 
     def __str__(self):
         header = '''
@@ -338,7 +338,7 @@ class LineFitWLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        super().__init__(a,b,ssr,N)
+        LineFit.__init__(self,a,b,ssr,N)
 
     def __str__(self):
         header = '''

--- a/GTC/type_a.py
+++ b/GTC/type_a.py
@@ -125,7 +125,7 @@ class LineFitOLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        LineFit.__init__(self,a,b,ssr,N)
+        super().__init__(a,b,ssr,N)
             
     def __str__(self):
         header = '''
@@ -235,7 +235,7 @@ class LineFitRWLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        LineFit.__init__(self,a,b,ssr,N)
+        super().__init__(a,b,ssr,N)
 
     def __str__(self):
         header = '''
@@ -338,7 +338,7 @@ class LineFitWLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        LineFit.__init__(self,a,b,ssr,N)
+        super().__init__(a,b,ssr,N)
 
     def __str__(self):
         header = '''

--- a/GTC/type_b.py
+++ b/GTC/type_b.py
@@ -244,7 +244,7 @@ class LineFitOLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        super().__init__(a,b,ssr,N)
+        LineFit.__init__(self,a,b,ssr,N)
 
     def __str__(self):
         header = '''
@@ -312,7 +312,7 @@ class LineFitWLS(LineFitOLS):
     """
     
     def __init__(self,a,b,ssr,N):
-        super().__init__(a,b,ssr,N)
+        LineFitOLS.__init__(self,a,b,ssr,N)
 
     def __str__(self):
         header = '''
@@ -331,7 +331,7 @@ class LineFitWTLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        super().__init__(a,b,ssr,N)
+        LineFit.__init__(self,a,b,ssr,N)
 
     def __str__(self):
         header = '''

--- a/GTC/type_b.py
+++ b/GTC/type_b.py
@@ -167,7 +167,7 @@ def mean(seq,*args,**kwargs):
     # If `seq` has uncertain number elements then `mu` will be an uncertain number.     
     return mu
 #-----------------------------------------------------------------------------------------
-class LineFit(object):
+class LineFit:
     
     """
     Base class for the results of regression to a line.
@@ -244,7 +244,7 @@ class LineFitOLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        LineFit.__init__(self,a,b,ssr,N)
+        super().__init__(a,b,ssr,N)
 
     def __str__(self):
         header = '''
@@ -312,7 +312,7 @@ class LineFitWLS(LineFitOLS):
     """
     
     def __init__(self,a,b,ssr,N):
-        LineFitOLS.__init__(self,a,b,ssr,N)
+        super().__init__(a,b,ssr,N)
 
     def __str__(self):
         header = '''
@@ -331,7 +331,7 @@ class LineFitWTLS(LineFit):
     """
     
     def __init__(self,a,b,ssr,N):
-        LineFit.__init__(self,a,b,ssr,N)
+        super().__init__(a,b,ssr,N)
 
     def __str__(self):
         header = '''
@@ -741,7 +741,7 @@ def _arrays(sin_a,cos_a,sin_2a,cos_2a,x,y,u2_x,u2_y,cov):
     return v_k,u2_x,u2_y,g_k,u2,x_bar,y_bar,p_hat
 
 #--------------------------------------------------------------------
-class ChiSq(object):
+class ChiSq:
 
     """
     A callable object representing Chi-squared as a function of alpha.
@@ -818,7 +818,7 @@ class ChiSq(object):
         return chi_2
 
 #--------------------------------------------------------------------
-class dChiSq_dalpha(object):
+class dChiSq_dalpha:
 
     """
     Callable object representing the derivative of Chi-squared wrt alpha. 

--- a/GTC/vector.py
+++ b/GTC/vector.py
@@ -55,7 +55,7 @@ __all__ = (
 
 # INF = ( '\U0010FFFF', float('inf') )
 INF = ( float('inf'), float('inf') )
-class INF_UID(object): uid = INF
+class INF_UID: uid = INF
         
 #--------------------------------------------------------------
 # TODO:
@@ -64,7 +64,7 @@ class INF_UID(object): uid = INF
 #
 # Look at using the bisect module to improve performance
 #
-class Vector(object):
+class Vector:
     
     """
     A Vector is a collection of ordered index-value pairs.

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -917,7 +917,7 @@ from GTC.type_b import _arrays
     # return v_k,u2_x,u2_y,g_k,u2,x_bar,y_bar,p_hat
 
 #--------------------------------------------------------------------
-class _Chi(object):
+class _Chi:
 
     """
     Defines a callable object that can be used in the Brent minimum-search.

--- a/test/test_function.py
+++ b/test/test_function.py
@@ -30,7 +30,7 @@ from testing_tools import *
 TOL = 1E-13 
           
 #---------------------------------------------------------
-class StdDataSets(object):
+class StdDataSets:
     """
     See section 5 in:
     'Design and us of reference data sets for testing scientific software'

--- a/test/test_type_a.py
+++ b/test/test_type_a.py
@@ -23,7 +23,7 @@ from testing_tools import *
 TOL = 1E-13 
             
 #---------------------------------------------------------
-class StdDataSets(object):
+class StdDataSets:
     """
     See section 5 in:
     'Design and us of reference data sets for testing scientific software'

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -22,7 +22,7 @@ from testing_tools import *
 #----------------------------------------------------------------------------
 # The index of a vector is an object that must have a `uid` attribute
 #
-class Dummy(object):
+class Dummy:
     def __init__(self,uid):
         self.uid = (uid, 0)
         


### PR DESCRIPTION
Python 3 uses the [new-style class](https://docs.python.org/3/glossary.html#term-new-style-class) syntax by default.

The following changes were made in this PR:
* a class is no longer required to explicitly inherit from `object`
* ~~call [super()](https://docs.python.org/3/library/functions.html#super) to initialise parent class~~