### PR TITLE
cleanup imports and builtin names

### DIFF
--- a/GTC/LU.py
+++ b/GTC/LU.py
@@ -6,14 +6,10 @@ Provides LU decomposition functions for Python objects stored in 2D arrays.
 :func:`ludcmp` performs LU decomposition
 :func:`invab` 
 """
+import array
 from functools import reduce
-try:
-    xrange  # Python 2
-except NameError:
-    xrange = range
 
 import numpy as np 
-import array
 
 __all__ = (
     'solve'
@@ -58,9 +54,9 @@ def ludcmp(a):
     vv = array.array('d',[0.0] * N)   
     parity = 1
 
-    for i in xrange(N):
+    for i in range(N):
         big = 0.0
-        for j in xrange(N):
+        for j in range(N):
             temp = abs( a[i,j] )
             big = temp if temp > big else big
                 
@@ -69,19 +65,19 @@ def ludcmp(a):
         except ZeroDivisionError:
             raise RuntimeError('zero column')
             
-    for j in xrange(N):
-        for i in xrange(j):
+    for j in range(N):
+        for i in range(j):
             a[i,j] = reduce(
                 lambda sum,k: sum - (a[i,k] * a[k,j]), 
-                    xrange(i),  # for k in xrange(i)
+                    range(i),  # for k in range(i)
                     a[i,j]      # initial value
             )
 
         big = 0.0
-        for i in xrange(j,N):
+        for i in range(j,N):
             a[i,j] = reduce(
                 lambda sum,k: sum - (a[i,k] * a[k,j]), 
-                    xrange(j),  # for k in xrange(j)
+                    range(j),  # for k in range(j)
                     a[i,j]      # initial value
             )
             dum = vv[i] * abs(a[i,j])
@@ -90,7 +86,7 @@ def ludcmp(a):
                 imax = i
             
         if(j != imax):
-            for k in xrange(N):
+            for k in range(N):
                 a[imax,k], a[j,k] = a[j,k], a[imax,k]
             parity *= -1
             vv[imax] = vv[j]
@@ -101,7 +97,7 @@ def ludcmp(a):
         
         if(j != N-1):
             tmp = 1.0 / a[j,j]
-            for i in xrange(j+1,N):
+            for i in range(j+1,N):
                 a[i,j] *= tmp
 
     return (a,indx,parity)
@@ -137,20 +133,20 @@ def _lubksb(a_lu,idx,b):
     N = a_lu.shape[0]
 
     ii = -1
-    for i in xrange(N):
+    for i in range(N):
         ip = idx[i]
         sum, b[ip] = b[ip], b[i]
         if( ii != -1 ):
-            for j in xrange(ii,i):
+            for j in range(ii,i):
                 sum -= a_lu[i,j] * b[j]
         elif(sum != 0.0):
             ii = i
         b[i] = sum
 
-    for i in xrange(N-1,-1,-1):
+    for i in range(N-1,-1,-1):
         b[i] = reduce(
             lambda sum,j: sum - a_lu[i,j]*b[j],
-            xrange(i+1,N),
+            range(i+1,N),
             b[i]
         )/a_lu[i,i]
             
@@ -181,13 +177,13 @@ def invab(a,b):
     y = np.empty( (N,M), a.dtype )
 
     # For each column in matrix `b`
-    for j in xrange(M):
+    for j in range(M):
     
         # TODO: consider a slice here
-        col = _lubksb(a_lu,idx,[ b[i,j] for i in xrange(N) ])
+        col = _lubksb(a_lu,idx,[ b[i,j] for i in range(N) ])
         
         # TODO: consider a slice here
-        for i in xrange(N):
+        for i in range(N):
             y[i,j] = col[i]
             
     return y
@@ -216,7 +212,7 @@ def ludet(a_lu,p):
         
     return reduce(
         lambda p,i: p * a_lu[i,i],
-        xrange(Nx),
+        range(Nx),
         p
     )
 

--- a/GTC/__init__.py
+++ b/GTC/__init__.py
@@ -8,14 +8,8 @@ in the 'Guide to the Expression of Uncertainty in Measurement' - the GUM.
 """
 import math
 import cmath
-import sys 
-
-try:
-    basestring  # Python 2
-    from collections import Sequence
-except NameError:
-    basestring = (str, bytes)
-    from collections.abc import Sequence
+import sys
+from collections.abc import Sequence
 
 #----------------------------------------------------------------------------
 # Global constants, etc
@@ -32,7 +26,7 @@ EPSILON = sys.float_info.epsilon
 # Note numpy arrays are not detected as sequences
 # by this function.
 def is_sequence(obj):
-    if isinstance(obj, basestring):
+    if isinstance(obj, (str, bytes)):
         return False
     else:
         return isinstance(obj, Sequence)

--- a/GTC/context.py
+++ b/GTC/context.py
@@ -4,10 +4,6 @@ Copyright (c) 2024, Measurement Standards Laboratory of New Zealand.
 """
 import uuid
 import weakref
-try:
-    long  # Python 2
-except NameError:
-    long = int
 
 from GTC.nodes import (
     Leaf,
@@ -34,8 +30,8 @@ class Context:
         # Context IDs will be unique - user beware!)
         self._id = uuid.uuid4().int if id is None else id
     
-        self._elementary_id_counter = long(0)
-        self._intermediate_id_counter = long(0)
+        self._elementary_id_counter = 0
+        self._intermediate_id_counter = 0
   
         # Caching to avoid duplication when unpacking archives 
         self._registered_leaf_nodes = weakref.WeakValueDictionary()

--- a/GTC/core.py
+++ b/GTC/core.py
@@ -3,19 +3,13 @@ import cmath
 import numbers
 import warnings
 
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-
 from GTC import lib
 from GTC import reporting
 from GTC import type_b
 from GTC import type_a
 from GTC import persistence
 from GTC import function
-
-from GTC import (   
+from GTC import (
     inf,
     nan,
     is_sequence,
@@ -388,7 +382,7 @@ def multiple_ureal(x_seq,u_seq,df,label_seq=None):
     rtn = [
         # NB `ureal` creates constant objects when u == 0
         ureal(x_i,u_i,df,label=l_i,independent=False)
-            for x_i,u_i,l_i in izip(
+            for x_i,u_i,l_i in zip(
                 x_seq,u_seq,label_seq
             )
     ]
@@ -666,7 +660,7 @@ def multiple_ucomplex(x_seq,u_seq,df,label_seq=None):
         # When the uncertainty term u_i corresponds to zero, 
         # constant ucomplex objects are created
         ucomplex(x_i,u_i,df,label=l_i,independent=False)
-            for x_i,u_i,l_i in izip(
+            for x_i,u_i,l_i in zip(
                 x_seq,u_seq,label_seq
             )
     ]

--- a/GTC/function.py
+++ b/GTC/function.py
@@ -15,30 +15,24 @@ Module contents
 
 """
 import math
-import numpy as np 
-from GTC.type_b import mean 
+import builtins
+from collections.abc import Iterable
 
-try:  # Python 2
-    import __builtin__ as builtins
-    from collections import Iterable
-    from itertools import izip
-except ImportError:
-    import builtins
-    from collections.abc import Iterable
-    izip = zip
-    xrange = range
+import numpy as np
 
+from GTC.type_b import mean
 from GTC import (
     is_sequence,
-    inf ,
+    inf,
     EPSILON
 )
-
 from GTC.lib import (
-    UncertainReal, UncertainComplex, 
-    mult_2nd_real_pair, mult_2nd_complex_pair,mult_2nd_real_complex
+    UncertainReal,
+    UncertainComplex,
+    mult_2nd_real_pair,
+    mult_2nd_complex_pair,
+    mult_2nd_real_complex
 )
-
 from GTC import vector
         
 __all__ = (
@@ -463,7 +457,7 @@ def nr_get_root(fn,x_min,x_max,epsilon):
     f = value( f_x )
     df = f_x.sensitivity(x)
 
-    for i in xrange(100): 
+    for i in range(100):
         if  (((xk-upper) * df-f) * ((xk-lower) * df - f) > 0.0
             or  ( abs(2.0 * f) > abs(dx2 * df) )):
             # Bisect if Newton out of range or

--- a/GTC/lib.py
+++ b/GTC/lib.py
@@ -8,16 +8,9 @@ import cmath
 import numbers
 import warnings
 
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-    long = int
-
 from GTC import nodes
 from GTC import vector 
 from GTC import context
-
 from GTC.named_tuples import (
     VarianceCovariance, 
     VarianceAndDof, 
@@ -27,7 +20,6 @@ from GTC.named_tuples import (
     CorrelationMatrix,
     CovarianceMatrix,
 )
-
 from GTC import (
     inf, 
     nan, 
@@ -2228,7 +2220,7 @@ def welch_satterthwaite(x):
         else:
             # Final calculation of WS 
             den = 0.0
-            for v_i,dof_i in izip(cpts_lst,dof_lst):
+            for v_i,dof_i in zip(cpts_lst,dof_lst):
                 if not math.isinf(dof_i):
                     u2 = v_i / var
                     den += u2 * u2 / dof_i

--- a/GTC/linear_algebra.py
+++ b/GTC/linear_algebra.py
@@ -75,11 +75,6 @@ Module contents
 ---------------
 
 """
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-
 import numpy as np
 
 from GTC import (
@@ -173,7 +168,7 @@ def uarray(array, label=None, names=None):
         if a_len != len(names):
             raise ValueError(f'len(array[0]) != len(names) -> {a_len} != {len(names)}')
 
-        dtype = [(name, type(val)) for name, val in izip(names, array[0])]
+        dtype = [(name, type(val)) for name, val in zip(names, array[0])]
 
     return UncertainArray(array, dtype=dtype, label=label)
 
@@ -221,7 +216,7 @@ def matmul(lhs, rhs):
     slices = np.array([[slice(None), slice(None)]]).repeat(len(indices), axis=0)
     i1 = np.hstack((i1, slices))
     i2 = np.hstack((i2, slices))
-    out = np.array([matmul(lhs[tuple(a)], rhs[tuple(b)]) for a, b in izip(i1, i2)])
+    out = np.array([matmul(lhs[tuple(a)], rhs[tuple(b)]) for a, b in zip(i1, i2)])
     return UncertainArray(out.reshape(list(broadcast.shape) + [lhs.shape[-2], rhs.shape[-1]]))
 
 

--- a/GTC/persistence.py
+++ b/GTC/persistence.py
@@ -27,7 +27,7 @@ Module contents
 
 """
 import json
-import xml.etree.cElementTree as ElementTree
+import xml.etree.ElementTree as ElementTree
 
 from GTC.archive import Archive
 

--- a/GTC/reporting.py
+++ b/GTC/reporting.py
@@ -46,25 +46,16 @@ Module contents
 """
 import math
 import numbers
-
 from operator import attrgetter as getter
 from functools import reduce
 
 from scipy import special, optimize
 
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-    long = int
-
 from GTC.named_tuples import (
-    ComponentOfUncertainty,     # relates to complex quantities
     Influence,
     Component                   
 )
 from GTC.vector import extend_vector
-
 from GTC import (
     is_sequence,
     inf,
@@ -583,7 +574,7 @@ def components(y,**kwargs):
         if len(values):
             cut_off = max(values) * float(trim)
             this_budget = [ Component( uid=n, u=u )
-                            for (u,n) in izip(values,uids) if u >= cut_off ]
+                            for (u,n) in zip(values,uids) if u >= cut_off ]
         else:
             this_budget = [ ]
         
@@ -697,7 +688,7 @@ def components(y,**kwargs):
             cut_off = max(values) * float(trim)
             this_budget = [ 
                 Component( uid=n, u=u ) 
-                    for (u,n) in izip(values,uids) 
+                    for (u,n) in zip(values,uids)
                         if u >= cut_off  
             ]
             
@@ -867,7 +858,7 @@ def budget(y,**kwargs):
         if len(values):
             cut_off = max(values) * float(trim)
             this_budget = [ Influence( label=n, u=u, uid=uid )
-                            for (u,n,uid) in izip(values,labels,uids) if u >= cut_off ]
+                            for (u,n,uid) in zip(values,labels,uids) if u >= cut_off ]
         else:
             this_budget = [ ]
         
@@ -1014,7 +1005,7 @@ def budget(y,**kwargs):
             cut_off = max(values) * float(trim)
             this_budget = [ 
                 Influence( label=n, u=u, uid=uid ) 
-                    for (u,n,uid) in izip(values,labels,uids) 
+                    for (u,n,uid) in zip(values,labels,uids)
                         if u >= cut_off  
             ]
             

--- a/GTC/type_b.py
+++ b/GTC/type_b.py
@@ -71,33 +71,20 @@ Module contents
 """
 import sys
 import math
+from collections.abc import Iterable
 
 import numpy as np
 
-try:  # Python 2
-    import __builtin__ as builtins
-    from collections import Iterable
-    from itertools import izip
-except ImportError:
-    import builtins
-    from collections.abc import Iterable
-    izip = zip
-    xrange = range
-    
 from GTC import (
-    inf ,
+    inf,
     EPSILON,
-    is_sequence
-
+    is_sequence,
 )
-
 from GTC.named_tuples import InterceptSlope
 from GTC.vector import scale_vector
-
 from GTC.lib import (
     UncertainReal,
     value,
-    value_seq
 )
 
 __all__ = (
@@ -375,7 +362,7 @@ def line_fit(x,y):
         >>> b0 = -3
         >>> u0 = .2
 
-        >>> x = [ float(x_i) for x_i in xrange(10) ]
+        >>> x = [ float(x_i) for x_i in range(10) ]
         >>> y = [ ureal(b0*x_i + a0,u0) for x_i in x ]
 
         >>> a,b = tb.line_fit(x,y).a_b
@@ -399,7 +386,7 @@ def line_fit(x,y):
 
     S_tt = sum( t_i*t_i for t_i in t )
     
-    b = sum( t_i*y_i/S_tt for t_i,y_i in izip(t,y) )
+    b = sum( t_i*y_i/S_tt for t_i,y_i in zip(t,y) )
     a = (S_y - b*S_x)/N
 
     if not isinstance(a, UncertainReal):
@@ -416,7 +403,7 @@ def line_fit(x,y):
     
     ssr =  math.fsum( 
         f2( value(x_i), value(y_i) ) 
-            for x_i,y_i in izip(x,y) 
+            for x_i,y_i in zip(x,y)
     )
 
     return LineFitOLS(a,b,ssr,N)
@@ -483,15 +470,15 @@ def line_fit_wls(x,y,u_y=None):
         u = u_y     
         
     S = sum( 1.0/v_i for v_i in v)
-    S_x = sum( x_i/v_i for x_i,v_i in izip(x,v) )    
-    S_y = sum( y_i/v_i for y_i,v_i in izip(y,v) )
+    S_x = sum( x_i/v_i for x_i,v_i in zip(x,v) )
+    S_y = sum( y_i/v_i for y_i,v_i in zip(y,v) )
 
     k = S_x / S
-    t = [ (x_i - k)/u_i for x_i,u_i in izip(x,u) ]
+    t = [ (x_i - k)/u_i for x_i,u_i in zip(x,u) ]
 
     S_tt = sum( t_i*t_i for t_i in t )
 
-    b = sum( t_i*y_i/u_i/S_tt for t_i,y_i,u_i in izip(t,y,u) )
+    b = sum( t_i*y_i/u_i/S_tt for t_i,y_i,u_i in zip(t,y,u) )
     a = (S_y - b*S_x)/S
 
     if not isinstance(a, UncertainReal):
@@ -508,7 +495,7 @@ def line_fit_wls(x,y,u_y=None):
     
     ssr =  math.fsum( 
         f2( value(x_i), value(y_i), u_i ) 
-            for x_i,y_i,u_i in izip(x,y,u) 
+            for x_i,y_i,u_i in zip(x,y,u)
     )
 
     return LineFitWLS(a,b,ssr,len(x))
@@ -562,7 +549,7 @@ def _dbrent(ax,bx,cx,fn,tol=math.sqrt(EPSILON)):
     # value of `w`, `u` is the point at which the function was most 
     # recently evaluated.
     
-    for i in xrange(ITMAX):
+    for i in range(ITMAX):
         
         xm = 0.5*(a + b)
         tol1 = tol*abs(x) + ZEPS
@@ -704,13 +691,13 @@ def _arrays(sin_a,cos_a,sin_2a,cos_2a,x,y,u2_x,u2_y,cov):
     # eqn(53)
     g_k = [
         (u2_x_i + u2_y_i)/2.0 - (u2_x_i - u2_y_i)*cos_2a/2.0 - 2.0*cov_i*sin_2a
-            for u2_x_i, u2_y_i, cov_i in izip(u2_x,u2_y,cov)
+            for u2_x_i, u2_y_i, cov_i in zip(u2_x,u2_y,cov)
     ]
 
 ##    # eqn(32)
 ##    g_k = [
 ##        u2_x_i*sin_a_2 + u2_y_i*cos_a_2 - two_sin_cos_a*cov_i
-##            for u2_x_i, u2_y_i, cov_i in izip(u2_x,u2_y,cov)
+##            for u2_x_i, u2_y_i, cov_i in zip(u2_x,u2_y,cov)
 ##    ]
 
     N = len(g_k)
@@ -726,17 +713,17 @@ def _arrays(sin_a,cos_a,sin_2a,cos_2a,x,y,u2_x,u2_y,cov):
 
     # Eqns (35,36,43)
     x_bar = sum(
-        w_k_i*x_i for w_k_i,x_i in izip(w_k,x)
+        w_k_i*x_i for w_k_i,x_i in zip(w_k,x)
     ) / N
     
     y_bar = sum(
-        w_k_i*y_i for w_k_i,y_i in izip(w_k,y)
+        w_k_i*y_i for w_k_i,y_i in zip(w_k,y)
     ) / N
 
     p_hat = y_bar*cos_a - x_bar*sin_a    
     
     # eqn(31)
-    v_k = [ y_i*cos_a - x_i*sin_a - p_hat for x_i,y_i in izip(x,y) ]  
+    v_k = [ y_i*cos_a - x_i*sin_a - p_hat for x_i,y_i in zip(x,y) ]
 
     return v_k,u2_x,u2_y,g_k,u2,x_bar,y_bar,p_hat
 
@@ -766,14 +753,14 @@ class ChiSq:
             self.u2_x = [ u_i**2 for u_i in u_x ]
             self.u2_y = [ u_i**2 for u_i in u_y ]
             self.cov = [ u_x_i*u_y_i*r_i
-                for u_x_i,u_y_i,r_i in izip(u_x,u_y,r_xy) 
+                for u_x_i,u_y_i,r_i in zip(u_x,u_y,r_xy)
             ]  
         else:    
             self.u2_x = [ x_i.v for x_i in x ]
             self.u2_y = [ y_i.v for y_i in y ]
         
             self.cov = [ x_i.get_covariance(y_i)
-                for x_i,y_i in izip(x,y)
+                for x_i,y_i in zip(x,y)
             ]
         
     #--------------------------------------------------------------------
@@ -812,7 +799,7 @@ class ChiSq:
             
         # Eqn (30)
         chi_2 = sum(
-            v_k_i**2/g_k_i for v_k_i,g_k_i in izip(v_k,g_k)
+            v_k_i**2/g_k_i for v_k_i,g_k_i in zip(v_k,g_k)
         )
         
         return chi_2
@@ -844,13 +831,13 @@ class dChiSq_dalpha:
             self.u2_x = [ u_i**2 for u_i in u_x ]
             self.u2_y = [ u_i**2 for u_i in u_y ]
             self.cov = [ u_x_i*u_y_i*r_i
-                for u_x_i,u_y_i,r_i in izip(u_x,u_y,r_xy) 
+                for u_x_i,u_y_i,r_i in zip(u_x,u_y,r_xy)
             ]  
         else:
             self.u2_x = [ x_i.v for x_i in x ]
             self.u2_y = [ y_i.v for y_i in y ]
             self.cov = [ x_i.get_covariance(y_i)
-                for x_i,y_i in izip(x,y) 
+                for x_i,y_i in zip(x,y)
             ]      
         
     #--------------------------------------------------------------------
@@ -867,11 +854,11 @@ class dChiSq_dalpha:
         )
 
         # d(v_k)_d(alpha)
-        v_ka = [ -y_i*sin_a - x_i*cos_a for x_i,y_i in izip(self.x,self.y) ]
+        v_ka = [ -y_i*sin_a - x_i*cos_a for x_i,y_i in zip(self.x,self.y) ]
         
         # d(g_k)_d(alpha)
         g_ka = [ sin_2a*(u2_x_i-u2_y_i) - 2.0*cov_i*cos_2a
-            for u2_x_i,u2_y_i,cov_i in izip(u2_x,u2_y,self.cov) ]
+            for u2_x_i,u2_y_i,cov_i in zip(u2_x,u2_y,self.cov) ]
         
         return v_k, v_ka, g_k, g_ka
 
@@ -889,7 +876,7 @@ class dChiSq_dalpha:
         dy_dx = sum(
            (2.0*v_k_i*g_k_i*v_ka_i - v_k_i**2*g_ka_i)/g_k_i**2
                 for v_k_i,v_ka_i,g_k_i,g_ka_i
-                    in izip(v_k, v_ka, g_k, g_ka)
+                    in zip(v_k, v_ka, g_k, g_ka)
         )
         
         return dy_dx
@@ -969,7 +956,7 @@ def line_fit_wtls(x,y,u_x=None,u_y=None,a_b=None,r_xy=None):
                 f"incompatible sequence lengths: {u_x!r}, {u_y!r}"
             )
 
-    for x_i,y_i in izip(x,y):
+    for x_i,y_i in zip(x,y):
         assert isinstance(x_i,UncertainReal), 'uncertain real required'
         assert isinstance(y_i,UncertainReal), 'uncertain real required'
 

--- a/GTC/uncertain_array.py
+++ b/GTC/uncertain_array.py
@@ -5,22 +5,15 @@ The proper way to create an uncertain array is by calling :func:`.uarray`
 # Our need is to provide convenient containers for uncertain numbers.
 # We do not try to integrate uncertain numbers in numpy's design.
 import warnings
-
 from numbers import Number, Real, Complex
 from math import isnan, isinf
 from cmath import isnan as cisnan
 from cmath import isinf as cisinf
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-    xrange = range
 
 import numpy as np
 
 from GTC import is_sequence
 from GTC.linear_algebra import matmul
-
 from GTC.core import (
     value,
     uncertainty,
@@ -48,7 +41,6 @@ from GTC.core import (
     phase,
     result,
 )
-
 from GTC.lib import (
     UncertainReal,
     UncertainComplex
@@ -210,9 +202,9 @@ class UncertainArray(np.ndarray):
         if len(inputs) == 1:
             return a, inputs[0].flat, shape
         if isinstance(inputs[0], np.ndarray):
-            return a, izip(inputs[0].flat, inputs[1].flat), shape
+            return a, zip(inputs[0].flat, inputs[1].flat), shape
         # then the inputs are already broadcasted iterators
-        return a, izip(*inputs), shape
+        return a, zip(*inputs), shape
 
     @property
     def label(self):
@@ -692,7 +684,7 @@ class UncertainArray(np.ndarray):
                 # Add index notation to the label base
                 labels = [
                     f"{labels}[{i}]"
-                    for i in xrange(self.size)
+                    for i in range(self.size)
                 ]
 
             labels = np.asarray(labels)

--- a/GTC/vector.py
+++ b/GTC/vector.py
@@ -18,11 +18,7 @@ of elements is checked when appending (but not during construction).
 Copyright (c) 2024, Measurement Standards Laboratory of New Zealand.
 
 """
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-    cmp = lambda a, b: (a > b) - (a < b)
+cmp = lambda a, b: (a > b) - (a < b)
 
 __all__ = (
     'Vector',
@@ -133,7 +129,7 @@ class Vector:
         return iter(self._index)
 
     def __str__(self):
-        return str( dict( izip(self._index,self._value) ) )
+        return str( dict( zip(self._index,self._value) ) )
 
     def __contains__(self,i):
         return i in self._index
@@ -168,7 +164,7 @@ class Vector:
         return self._value
 
     def iteritems(self):
-        return izip(self._index,self._value)
+        return zip(self._index,self._value)
     
     def iterkeys(self):
         return iter(self._index)
@@ -287,7 +283,7 @@ def merge_vectors(v1,v2):
 
     if v1._index == v2._index:
         # No need to check indices => much faster
-        value = [ x1 + x2 for (x1,x2) in izip(v1._value,v2._value) ]
+        value = [ x1 + x2 for (x1,x2) in zip(v1._value,v2._value) ]
         index = v1._index
     else:
         # A marker at the ends: must remove afterwards!
@@ -361,7 +357,7 @@ def merge_weighted_vectors(v1,w1,v2,w2):
 
     if v1._index == v2._index:
         # No need to check indices => much faster
-        value = [ w1*x1 + w2*x2 for (x1,x2) in izip(v1._value,v2._value) ]
+        value = [ w1*x1 + w2*x2 for (x1,x2) in zip(v1._value,v2._value) ]
         index = v1._index
     else:
         # A marker at the ends: must remove afterwards!
@@ -470,8 +466,8 @@ def merge_weighted_vectors_twice(v1,w1,v2,w2):
     w12,w22 = w2
     if v1._index == v2._index:
         # No need to check indices => much faster
-        value1 = [ w11*x1 + w12*x2 for (x1,x2) in izip(v1._value,v2._value) ]
-        value2 = [ w21*x1 + w22*x2 for (x1,x2) in izip(v1._value,v2._value) ]
+        value1 = [ w11*x1 + w12*x2 for (x1,x2) in zip(v1._value,v2._value) ]
+        value2 = [ w21*x1 + w22*x2 for (x1,x2) in zip(v1._value,v2._value) ]
         index = v1._index
     else:
         # A marker at the ends: must remove afterwards!

--- a/GTC/xml_format.py
+++ b/GTC/xml_format.py
@@ -4,7 +4,7 @@ and then restoration of an Archive from XML.
 """
 from ast import literal_eval
 from math import isinf
-from xml.etree.cElementTree import (
+from xml.etree.ElementTree import (
     Element,
     SubElement,
 )

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,6 @@
 Injects GTC in to the doctest namespace for pytest.
 """
 import os
-import sys
 
 import pytest
 
@@ -18,6 +17,3 @@ def add_gtc(doctest_namespace):
         if key.startswith('_'):
             continue
         doctest_namespace[key] = val
-
-    if sys.version_info.major > 2:
-        doctest_namespace['xrange'] = range

--- a/test/test_LU.py
+++ b/test/test_LU.py
@@ -1,22 +1,15 @@
 import unittest
-import sys
-import math
-import cmath
-import numpy
-import operator
-import collections
-try:
-    xrange  # Python 2
-except NameError:
-    xrange = range
 
-TOL = 1E-13
-DIGITS = 13
+import numpy
 
 from GTC import *
 from GTC.LU import *
 
 from testing_tools import *
+
+TOL = 1E-13
+DIGITS = 13
+
 
 #-----------------------------------------------------------------------------------
 def one_port_xratio(measured,nominal):
@@ -135,8 +128,8 @@ class TestLUInvProduct(unittest.TestCase):
         # Calculate the inverse matrix
         a_inv = invab(a,numpy.identity(3))
         a_b = numpy.dot(a,a_inv)
-        for i in xrange(3):
-            for j in xrange(3):
+        for i in range(3):
+            for j in range(3):
                 if i == j:
                     self.assertTrue( equivalent(1.0,a_b[i,i]) )   
                 else:
@@ -147,8 +140,8 @@ class TestLUInvProduct(unittest.TestCase):
         b = numpy.dot(a,x)
         
         a_b = invab(a,b)
-        for i in xrange(a_b.shape[0]):
-            for j in xrange(a_b.shape[1]):
+        for i in range(a_b.shape[0]):
+            for j in range(a_b.shape[1]):
                 self.assertTrue( equivalent(x[i,j],a_b[i,j]) )
 
 #-----------------------------------------------------

--- a/test/test_archive_copy_constructor.py
+++ b/test/test_archive_copy_constructor.py
@@ -1,10 +1,5 @@
 import unittest
 import os
-import sys
-
-import json
-
-from lxml import etree
 
 from GTC import *
 

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -1,23 +1,7 @@
 import unittest
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-    xrange = range
-
 import sys
-import numpy
 
 from GTC import *
-
-from GTC.lib import (
-    UncertainReal, 
-    UncertainComplex,
-    set_correlation_real,
-    real_ensemble,
-    complex_ensemble,
-    append_real_ensemble
-)
 
 from testing_tools import *
 
@@ -42,17 +26,17 @@ def simple_sigma_abr(x,y,u_y=None):
     v = [ u_i*u_i for u_i in u_y ]
         
     S = sum( 1.0/v_i for v_i in v)
-    S_x = sum( x_i/v_i for x_i,v_i in izip(x,v) )
-    S_xx = sum( x_i**2/v_i for x_i,v_i in izip(x,v) )
+    S_x = sum( x_i/v_i for x_i,v_i in zip(x,v) )
+    S_xx = sum( x_i**2/v_i for x_i,v_i in zip(x,v) )
 
-    S_y = sum( y_i/v_i for y_i,v_i in izip(y,v) )
+    S_y = sum( y_i/v_i for y_i,v_i in zip(y,v) )
 
     k = S_x / S
-    t = [ (x_i - k)/u_y_i for x_i,u_y_i in izip(x,u_y) ]
+    t = [ (x_i - k)/u_y_i for x_i,u_y_i in zip(x,u_y) ]
 
     S_tt = sum( t_i*t_i for t_i in t )
 
-    b = sum( t_i*y_i/u_y_i/S_tt for t_i,y_i,u_y_i in izip(t,y,u_y) )
+    b = sum( t_i*y_i/u_y_i/S_tt for t_i,y_i,u_y_i in zip(t,y,u_y) )
     a = (S_y - b*S_x)/S
 
     delta = S*S_xx - S_x**2
@@ -63,7 +47,7 @@ def simple_sigma_abr(x,y,u_y=None):
     if not weights:
         # Need chi-square to adjust the values
         f = lambda x_i,y_i,u_y_i: ((y_i - a - b*x_i))**2 
-        chisq = sum( f(x_i,y_i,u_y_i) for x_i,y_i,u_y_i in izip(x,y,u_y) )
+        chisq = sum( f(x_i,y_i,u_y_i) for x_i,y_i,u_y_i in zip(x,y,u_y) )
         data_u = math.sqrt( chisq/(N-2) )
         sigma_a *= data_u
         sigma_b *= data_u
@@ -402,7 +386,7 @@ class TestLineFitWeighted(unittest.TestCase):
         u0 = .2
         u = [u0] * N
         
-        x = [ float(x_i) for x_i in xrange(10) ]
+        x = [ float(x_i) for x_i in range(10) ]
         y = [ ureal(b0*x_i + a0,u0) for x_i in x ]
 
         a,b = type_b.line_fit_wls(x,y,u).a_b
@@ -430,7 +414,7 @@ class TestLineFitWeighted(unittest.TestCase):
         u0 = .2
         u = [u0] * N
         
-        x = [ float(x_i) for x_i in xrange(10) ]
+        x = [ float(x_i) for x_i in range(10) ]
         y = [ ureal(b0*x_i + a0,u0) for x_i in x ]
 
         a,b = ta.line_fit_wls(x,y,u).a_b
@@ -560,7 +544,7 @@ class UncertainLineTests(unittest.TestCase):
         uncertain number in y only with unity weight
 
         """
-        x = [ float(x_i) for x_i in xrange(10) ]
+        x = [ float(x_i) for x_i in range(10) ]
         y = [ ureal(y_i,1) for y_i in x ]
 
         fit = type_b.line_fit(x,y)
@@ -583,7 +567,7 @@ class UncertainLineTests(unittest.TestCase):
         equivalent(r,a.get_correlation(b),TOL)        
         
         # Horizontal line
-        x = [ float(x_i) for x_i in xrange(5) ]
+        x = [ float(x_i) for x_i in range(5) ]
         y = [ ureal(2,1) for y_i in x ]
         
         fit = type_b.line_fit(x,y)
@@ -617,8 +601,8 @@ class UncertainLineTests(unittest.TestCase):
 
         """
         N = 10
-        y = [ ureal(y_i,1) for y_i in xrange(N) ]
-        x = [ ureal(x_i,1) for x_i in xrange(N) ]
+        y = [ ureal(y_i,1) for y_i in range(N) ]
+        x = [ ureal(x_i,1) for x_i in range(N) ]
 
         a,b = type_b.line_fit( x,y ).a_b
         equivalent( value(a) ,0.0,TOL)
@@ -660,8 +644,8 @@ class UncertainLineTests(unittest.TestCase):
         u0 = .2
         u = [u0] * N
         
-        x = [ value(x_i) for x_i in xrange(10) ]
-        y = [ ureal(b0*x_i + a0,u_i) for x_i,u_i in izip(x,u) ]
+        x = [ value(x_i) for x_i in range(10) ]
+        y = [ ureal(b0*x_i + a0,u_i) for x_i,u_i in zip(x,u) ]
 
         a,b = type_b.line_fit_wls(x,y).a_b
 
@@ -683,7 +667,7 @@ class UncertainLineTests(unittest.TestCase):
     def test_horizontal_wls(self):
         
         # Horizontal line
-        x = [ float(x_i) for x_i in xrange(5) ]
+        x = [ float(x_i) for x_i in range(5) ]
         y = [ ureal(2,1) for y_i in x ]
         
         fit = type_b.line_fit_wls(x,y)
@@ -707,10 +691,10 @@ class UncertainLineTests(unittest.TestCase):
         u0 = .2
 
         N = 10        
-        x = [ ureal(x_i,u0) for x_i in xrange(N) ]
+        x = [ ureal(x_i,u0) for x_i in range(N) ]
         y = [ ureal( b0 * value(x_i) + a0, 1) for x_i in x ]    # unity uncertainty
 
-        u = [uncertainty(y_i - b0*x_i) for x_i,y_i in izip(x,y)]
+        u = [uncertainty(y_i - b0*x_i) for x_i,y_i in zip(x,y)]
 
         a,b = type_b.line_fit_wls(x,y).a_b
 
@@ -731,7 +715,7 @@ class UncertainLineTests(unittest.TestCase):
         equivalent(r,a.get_correlation(b),TOL)        
 
         # We can calculate the uncertainty sequence directly
-        d = [ math.sqrt(1 + (b0 * u0)**2) for i in xrange(N) ]
+        d = [ math.sqrt(1 + (b0 * u0)**2) for i in range(N) ]
         sig_a, sig_b, r = simple_sigma_abr(
             [value(x_i) for x_i in x],
             [value(y_i) for y_i in y],
@@ -805,7 +789,7 @@ def brent(a,b,c,fn,tol=math.sqrt(EPSILON)):
     x = w = v = b
     fx = fw = fv = fn(x)
 
-    for i in xrange(ITMAX):
+    for i in range(ITMAX):
 
         xm = 0.5*(a + b)
         tol1 = tol*abs(x) + ZEPS
@@ -883,12 +867,12 @@ from GTC.type_b import _arrays
     # # eqn(53)
     # g_k = [
         # (u2_x_i + u2_y_i)/2.0 - (u2_x_i - u2_y_i)*cos_2a/2.0 - 2.0*cov_i*sin_2a
-            # for u2_x_i, u2_y_i, cov_i in izip(u2_x,u2_y,cov)
+            # for u2_x_i, u2_y_i, cov_i in zip(u2_x,u2_y,cov)
     # ]
 # ##    # eqn(32)
 # ##    g_k = [
 # ##        u2_x_i*sin_a_2 + u2_y_i*cos_a_2 - two_sin_cos_a*cov_i
-# ##            for u2_x_i, u2_y_i, cov_i in izip(u2_x,u2_y,cov)
+# ##            for u2_x_i, u2_y_i, cov_i in zip(u2_x,u2_y,cov)
 # ##    ]
 
     # N = len(g_k)
@@ -902,17 +886,17 @@ from GTC.type_b import _arrays
 
     # # Eqns (35,36,43)
     # x_bar = sum(
-        # w_k_i*x_i for w_k_i,x_i in izip(w_k,x)
+        # w_k_i*x_i for w_k_i,x_i in zip(w_k,x)
     # ) / N
     
     # y_bar = sum(
-        # w_k_i*y_i for w_k_i,y_i in izip(w_k,y)
+        # w_k_i*y_i for w_k_i,y_i in zip(w_k,y)
     # ) / N
 
     # p_hat = y_bar*cos_a - x_bar*sin_a    
 
     # # eqn(31)
-    # v_k = [ y_i*cos_a - x_i*sin_a - p_hat for x_i,y_i in izip(x,y) ]  
+    # v_k = [ y_i*cos_a - x_i*sin_a - p_hat for x_i,y_i in zip(x,y) ]  
 
     # return v_k,u2_x,u2_y,g_k,u2,x_bar,y_bar,p_hat
 
@@ -933,7 +917,7 @@ class _Chi:
         self.u2_y = [ variance(y_i) for y_i in y ]
         
         self.cov = [ uncertainty(x_i)*x_i.get_correlation(y_i)*uncertainty(y_i)
-                         for x_i,y_i in izip(x,y)]
+                         for x_i,y_i in zip(x,y)]
         
     #--------------------------------------------------------------------
     def arrays(self,alpha):
@@ -954,7 +938,7 @@ class _Chi:
         
         # Eqn (30)
         chi_2 = sum(
-            v_k_i**2/g_k_i for v_k_i,g_k_i in izip(v_k,g_k)
+            v_k_i**2/g_k_i for v_k_i,g_k_i in zip(v_k,g_k)
         )
         
         return chi_2
@@ -976,7 +960,7 @@ def _WTLS(x,y,a0,b0):
     Meas. Sci. Technol. 22 (2011) 035101 (9pp)
     
     """
-    for x_i,y_i in izip(x,y):
+    for x_i,y_i in zip(x,y):
         assert reporting.is_ureal(x_i)
         assert reporting.is_ureal(y_i)
         
@@ -1017,29 +1001,29 @@ def _WTLS(x,y,a0,b0):
         sin_a,cos_a,sin_2a,cos_2a,x,y,u2_x,u2_y,data.cov
     )
     
-    v_ka = [ -y_i*sin_a - x_i*cos_a for x_i,y_i in izip(x,y)]
+    v_ka = [ -y_i*sin_a - x_i*cos_a for x_i,y_i in zip(x,y)]
     v_kaa = [ -v_k_i - p_hat for v_k_i in v_k ]
     f_k = [ v_k_i**2 for v_k_i in v_k ]
-    f_ka = [ 2.0*v_k_i*v_ka_i for v_k_i,v_ka_i in izip(v_k,v_ka)]
-    f_kaa = [ 2.0*(v_ka_i**2 + v_k_i*v_kaa_i) for v_k_i,v_ka_i,v_kaa_i in izip(v_k,v_ka,v_kaa)]
+    f_ka = [ 2.0*v_k_i*v_ka_i for v_k_i,v_ka_i in zip(v_k,v_ka)]
+    f_kaa = [ 2.0*(v_ka_i**2 + v_k_i*v_kaa_i) for v_k_i,v_ka_i,v_kaa_i in zip(v_k,v_ka,v_kaa)]
 
     g_ka = [ 
         (u2_x_i-u2_y_i)*sin_2a - 2.0*cov_i*cos_2a 
-            for u2_x_i,u2_y_i,cov_i in izip(u2_x,u2_y,data.cov)
+            for u2_x_i,u2_y_i,cov_i in zip(u2_x,u2_y,data.cov)
     ]
     k = 2.0*(cos_a**2 - sin_a**2)
-    g_kaa = [ k*(u2_x_i - u2_y_i) for u2_x_i,u2_y_i in izip(u2_x,u2_y) ]
+    g_kaa = [ k*(u2_x_i - u2_y_i) for u2_x_i,u2_y_i in zip(u2_x,u2_y) ]
     Hpp = 2*N/u2
     H_alpha_p = -2.0*sum(
         (v_ka_i*g_k_i - g_ka_i*v_k_i) / g_k_i**2
-            for g_k_i,v_k_i,g_ka_i,v_ka_i in izip(g_k,v_k,g_ka,v_ka)
+            for g_k_i,v_k_i,g_ka_i,v_ka_i in zip(g_k,v_k,g_ka,v_ka)
     )
     H_alpha_alpha = sum(
             f_kaa_i/g_k_i
         -   2.0*f_ka_i*g_ka_i/g_k_i**2
         +   2.0*g_ka_i**2*f_k_i/g_k_i**3
         -   g_kaa_i*f_k_i/g_k_i**2
-       for g_k_i,g_ka_i,g_kaa_i,f_k_i,f_ka_i,f_kaa_i in izip(g_k,g_ka,g_kaa,f_k,f_ka,f_kaa)
+       for g_k_i,g_ka_i,g_kaa_i,f_k_i,f_ka_i,f_kaa_i in zip(g_k,g_ka,g_kaa,f_k,f_ka,f_kaa)
     )
     NN = 2.0 / (Hpp*H_alpha_alpha - H_alpha_p**2)
     var_p = NN*H_alpha_alpha
@@ -1228,8 +1212,8 @@ class TestLineFitTLS(unittest.TestCase):
         uxin=[1./math.sqrt(wx_i) for wx_i in wx ]
         uyin=[1./math.sqrt(wy_i) for wy_i in wy ]
 
-        x = [ ureal(xin_i,uxin_i) for xin_i,uxin_i in izip(xin,uxin) ]
-        y = [ ureal(yin_i,uyin_i) for yin_i,uyin_i in izip(yin,uyin) ]
+        x = [ ureal(xin_i,uxin_i) for xin_i,uxin_i in zip(xin,uxin) ]
+        y = [ ureal(yin_i,uyin_i) for yin_i,uyin_i in zip(yin,uyin) ]
 
         # a0, b0 = tb.line_fit(x,y).a_b
         # result = tb.line_fit_wtls(x,y,a_b=(a0,b0))
@@ -1337,8 +1321,8 @@ class TestLineFitTLS(unittest.TestCase):
         uxin=[1./math.sqrt(wx_i) for wx_i in wx ]
         uyin=[1./math.sqrt(wy_i) for wy_i in wy ]
 
-        x = [ ureal(xin_i,uxin_i) for xin_i,uxin_i in izip(xin,uxin) ]
-        y = [ ureal(yin_i,uyin_i) for yin_i,uyin_i in izip(yin,uyin) ]
+        x = [ ureal(xin_i,uxin_i) for xin_i,uxin_i in zip(xin,uxin) ]
+        y = [ ureal(yin_i,uyin_i) for yin_i,uyin_i in zip(yin,uyin) ]
 
         # a0, b0 = tb.line_fit(x,y).a_b
         # result = ta.line_fit_wtls(x,y,u_x=uxin,u_y=uyin,a0_b0=(a0,b0))
@@ -1387,8 +1371,8 @@ class TestLineFitTLS(unittest.TestCase):
         uxin=[1./math.sqrt(wx_i) for wx_i in wx ]
         uyin=[1./math.sqrt(wy_i) for wy_i in wy ]
 
-        x = [ ureal(xin_i,uxin_i) for xin_i,uxin_i in izip(xin,uxin) ]
-        y = [ ureal(yin_i,uyin_i) for yin_i,uyin_i in izip(yin,uyin) ]
+        x = [ ureal(xin_i,uxin_i) for xin_i,uxin_i in zip(xin,uxin) ]
+        y = [ ureal(yin_i,uyin_i) for yin_i,uyin_i in zip(yin,uyin) ]
 
         # a0, b0 = tb.line_fit(x,y).a_b
         # result = tb.line_fit_wtls(x,y,a_b=(a0,b0))
@@ -1435,8 +1419,8 @@ class TestLineFitTLS(unittest.TestCase):
         uxin=[1./math.sqrt(wx_i) for wx_i in wx ]
         uyin=[1./math.sqrt(wy_i) for wy_i in wy ]
 
-        x = [ ureal(xin_i,uxin_i) for xin_i,uxin_i in izip(xin,uxin) ]
-        y = [ ureal(yin_i,uyin_i) for yin_i,uyin_i in izip(yin,uyin) ]
+        x = [ ureal(xin_i,uxin_i) for xin_i,uxin_i in zip(xin,uxin) ]
+        y = [ ureal(yin_i,uyin_i) for yin_i,uyin_i in zip(yin,uyin) ]
 
         # a0, b0 = ta.line_fit(x,y).a_b
         # a,b = ta.line_fit_wtls(x,y,u_x=uxin,u_y=uyin,a0_b0=(a0,b0)).a_b
@@ -1538,11 +1522,11 @@ class TestLineFitTLS(unittest.TestCase):
     
         un_x = [
             ureal(x_i,u_i,label=f"x_{i}" ) 
-                for i,x_i,u_i in zip(xrange(len(x)),x,ux)
+                for i,x_i,u_i in zip(range(len(x)),x,ux)
         ]
         un_y = [
             ureal(y_i,u_i,label=f"y_{i}") 
-                for i,y_i,u_i in zip(xrange(len(y)),y,uy)
+                for i,y_i,u_i in zip(range(len(y)),y,uy)
         ]
         
         # OLS initial estimate

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -4,7 +4,13 @@ import math
 import sys
 import unittest
 
-from GTC import ureal, ucomplex, inf_dof, inf, nan
+from GTC import (
+    ureal,
+    ucomplex,
+    inf_dof,
+    inf,
+    nan,
+)
 from GTC.formatting import (
     Format,
     create_format,
@@ -15,7 +21,10 @@ from GTC.formatting import (
     _order_of_magnitude,
     _truncate_dof,
 )
-from GTC.lib import UncertainReal, UncertainComplex
+from GTC.lib import (
+    UncertainReal,
+    UncertainComplex,
+)
 
 original_locale = locale.getlocale(locale.LC_NUMERIC)
 

--- a/test/test_function.py
+++ b/test/test_function.py
@@ -1,29 +1,16 @@
 import unittest
 import math
-try:
-    xrange  # Python 2
-except NameError:
-    xrange = range
-
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-    xrange = range
 
 import numpy as np
 
 from GTC import function
-
 from GTC.core import (
     ureal,
     ucomplex,
     value,
     uncertainty,
-    variance,
-    dof
 )
-from GTC.linear_algebra import matmul, uarray
+from GTC.linear_algebra import uarray
 
 from testing_tools import *
 
@@ -48,7 +35,7 @@ class StdDataSets:
         self._k = k
         
         N = self._n
-        a = np.array( xrange(-N,N+1) ) * self._h
+        a = np.array( range(-N,N+1) ) * self._h
         q = self._q ** self._k
         
         return (self._mu + q) - a

--- a/test/test_implicit.py
+++ b/test/test_implicit.py
@@ -1,13 +1,14 @@
 import unittest
 import math
 
-TOL = 1E-13
-DIGITS = 13
-
 from GTC import *
 from testing_tools import *
 
+TOL = 1E-13
+DIGITS = 13
+
 implicit = fn.implicit
+
 
 #-----------------------------------------------------
 class TestImplicit(unittest.TestCase):

--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -1,9 +1,5 @@
 import unittest
 import os
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
 
 from GTC import *
 from GTC.context import Context
@@ -225,7 +221,7 @@ class TestArchive(unittest.TestCase):
         self.assertTrue(
             all( 
                 z_i.uid == z1_i.uid 
-                    for (z_i, z1_i) in izip(
+                    for (z_i, z1_i) in zip(
                         z._i_components,z1._i_components) 
             )
         )

--- a/test/test_persistence_json.py
+++ b/test/test_persistence_json.py
@@ -1,17 +1,10 @@
 import unittest
 import os
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
 
 from GTC import *
 from GTC.context import Context
 from GTC import context
 from GTC import persistence
-from GTC.vector import is_ordered
-
-from testing_tools import *
 
 TOL = 1E-13 
 

--- a/test/test_second_order_mul.py
+++ b/test/test_second_order_mul.py
@@ -1,22 +1,6 @@
 import unittest
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-    xrange = range
-
-import numpy
 
 from GTC import *
-
-from GTC.lib import (
-    UncertainReal, 
-    UncertainComplex,
-    set_correlation_real,
-    real_ensemble,
-    complex_ensemble,
-    append_real_ensemble
-)
 
 from testing_tools import *
 

--- a/test/test_sensitivity.py
+++ b/test/test_sensitivity.py
@@ -1,18 +1,10 @@
 import unittest
-import os
-import numpy
-
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
 
 from GTC import *
-from GTC.context import Context
-from GTC import context
-from GTC import persistence
-from GTC.vector import is_ordered
-from GTC.linear_algebra import uarray, UncertainArray
+from GTC.linear_algebra import (
+    uarray,
+    UncertainArray,
+)
 
 from testing_tools import *
 

--- a/test/test_type_a.py
+++ b/test/test_type_a.py
@@ -1,22 +1,8 @@
 import unittest
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-    xrange = range
 
 import numpy
 
 from GTC import *
-
-from GTC.lib import (
-    UncertainReal, 
-    UncertainComplex,
-    set_correlation_real,
-    real_ensemble,
-    complex_ensemble,
-    append_real_ensemble
-)
 
 from testing_tools import *
 
@@ -41,7 +27,7 @@ class StdDataSets:
         self._k = k
         
         N = self._n
-        a = numpy.array( xrange(-N,N+1) ) * self._h
+        a = numpy.array( range(-N,N+1) ) * self._h
         q = self._q ** self._k
         
         return (self._mu + q) - a
@@ -145,7 +131,7 @@ class TestTypeA(unittest.TestCase):
         for k in range(5):
             re_seq = re_data_.seq(k)
             im_seq = im_data_.seq(k)
-            zseq = [ complex(i,j) for i,j in izip(re_seq,im_seq) ]
+            zseq = [ complex(i,j) for i,j in zip(re_seq,im_seq) ]
         
             self.assertTrue(
                 equivalent_complex(
@@ -165,7 +151,7 @@ class TestTypeA(unittest.TestCase):
 
         re_seq = re_data_.seq()
         im_seq = im_data_.seq()
-        zseq = [ ucomplex(complex(i,j),1.0) for i,j in izip(re_seq,im_seq) ]
+        zseq = [ ucomplex(complex(i,j),1.0) for i,j in zip(re_seq,im_seq) ]
         
         equivalent_complex(
             type_a.mean(zseq),
@@ -191,7 +177,7 @@ class TestTypeA(unittest.TestCase):
         for k in range(5):
             re_seq = re_data_.seq(k)
             im_seq = im_data_.seq(k)
-            zseq = [ complex(i,j) for i,j in izip(re_seq,im_seq) ]
+            zseq = [ complex(i,j) for i,j in zip(re_seq,im_seq) ]
 
             root_N = math.sqrt( len(zseq) )            
 
@@ -211,7 +197,7 @@ class TestTypeA(unittest.TestCase):
         
         re_seq = re_data_.seq()
         im_seq = im_data_.seq()
-        zseq = [ ucomplex( complex(i,j), 1) for i,j in izip(re_seq,im_seq) ]
+        zseq = [ ucomplex( complex(i,j), 1) for i,j in zip(re_seq,im_seq) ]
 
         root_N = math.sqrt( len(zseq) )            
 
@@ -239,7 +225,7 @@ class TestTypeA(unittest.TestCase):
         for k in range(5):
             re_seq = re_data_.seq(k)
             im_seq = im_data_.seq(k)
-            zseq = [ complex(i,j) for i,j in izip(re_seq,im_seq) ]
+            zseq = [ complex(i,j) for i,j in zip(re_seq,im_seq) ]
 
             root_N = math.sqrt( len(zseq) )            
 
@@ -263,7 +249,7 @@ class TestTypeA(unittest.TestCase):
         
         re_seq = re_data_.seq()
         im_seq = im_data_.seq()
-        zseq = [ complex(i,j) for i,j in izip(re_seq,im_seq) ]
+        zseq = [ complex(i,j) for i,j in zip(re_seq,im_seq) ]
 
         root_N = math.sqrt( len(zseq) )            
 

--- a/test/test_uncertain_array.py
+++ b/test/test_uncertain_array.py
@@ -4,10 +4,6 @@ import math
 import cmath
 import tempfile
 import sys
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
 
 import numpy as np
 
@@ -41,12 +37,32 @@ from GTC.core import (
     dof
 )
 
-from GTC import inf, nan
-from GTC.uncertain_array import UncertainArray, _isinf, _isnan
-from GTC.named_tuples import StandardUncertainty, VarianceCovariance
-from GTC.lib import UncertainReal, UncertainComplex
-from GTC import type_a, function, linear_algebra
-from GTC.linear_algebra import matmul, uarray
+from GTC import (
+    inf,
+    nan,
+)
+from GTC.uncertain_array import (
+    UncertainArray,
+    _isinf,
+    _isnan,
+)
+from GTC.named_tuples import (
+    StandardUncertainty,
+    VarianceCovariance,
+)
+from GTC.lib import (
+    UncertainReal,
+    UncertainComplex,
+)
+from GTC import (
+    type_a,
+    function,
+    linear_algebra,
+)
+from GTC.linear_algebra import (
+    matmul,
+    uarray,
+)
 
 from testing_tools import *
 
@@ -711,8 +727,8 @@ class TestUncertainArray(unittest.TestCase):
         n = len(self.x)
 
         # 1D array of uncertain numbers, no vectorization
-        z = [x + y for x, y in izip(self.x, self.y)]
-        zc = [x + y for x, y in izip(self.xc, self.yc)]
+        z = [x + y for x, y in zip(self.x, self.y)]
+        zc = [x + y for x, y in zip(self.xc, self.yc)]
         za = self.xa + self.ya
         zca = self.xca + self.yca
         for i in range(n):
@@ -725,8 +741,8 @@ class TestUncertainArray(unittest.TestCase):
         # 1D array of uncertain numbers, with vectorization
         # also switch the addition order to be y + x
         for m in range(n):
-            z = [y + x for y, x in izip(self.y[m:], self.x[m:])]
-            zc = [y + x for y, x in izip(self.yc[m:], self.xc[m:])]
+            z = [y + x for y, x in zip(self.y[m:], self.x[m:])]
+            zc = [y + x for y, x in zip(self.yc[m:], self.xc[m:])]
             za = self.ya[m:] + self.xa[m:]
             zca = self.yca[m:] + self.xca[m:]
             for i in range(n-m):
@@ -849,7 +865,7 @@ class TestUncertainArray(unittest.TestCase):
 
         # check addition with a list -> UncertainArray[ureal] + list
         my_list = list(range(n))
-        z = [x + val for x, val in izip(self.x, my_list)]
+        z = [x + val for x, val in zip(self.x, my_list)]
         za = self.xa + my_list
         for i in range(n):
             self.assertTrue(equivalent(z[i].x, za[i].x))
@@ -857,7 +873,7 @@ class TestUncertainArray(unittest.TestCase):
 
         # check addition with a list -> UncertainArray[ucomplex] + list
         my_list = [1+3j, 5j, -3+2.2j, 0.1+0.4j, 8., 1.9+3.4j]
-        zc = [x + val for x, val in izip(self.xc, my_list)]
+        zc = [x + val for x, val in zip(self.xc, my_list)]
         zca = self.xca + my_list
         for i in range(n):
             self.assertTrue(equivalent_complex(zc[i].x, zca[i].x))
@@ -866,7 +882,7 @@ class TestUncertainArray(unittest.TestCase):
 
         # check addition with a list -> list + UncertainArray[ureal]
         my_list = list(range(n))
-        z = [val + x for val, x in izip(my_list, self.x)]
+        z = [val + x for val, x in zip(my_list, self.x)]
         za = my_list + self.xa
         for i in range(n):
             self.assertTrue(equivalent(z[i].x, za[i].x))
@@ -874,7 +890,7 @@ class TestUncertainArray(unittest.TestCase):
 
         # check addition with a list -> list + UncertainArray[ucomplex]
         my_list = [3.1-2.3j, 4+5j, 3.2+7.3j, 5.1-0.4j, 0.1, 6.1+3.7j]
-        zc = [val + x for val, x in izip(my_list, self.xc)]
+        zc = [val + x for val, x in zip(my_list, self.xc)]
         zca = my_list + self.xca
         for i in range(n):
             self.assertTrue(equivalent_complex(zc[i].x, zca[i].x))
@@ -907,8 +923,8 @@ class TestUncertainArray(unittest.TestCase):
         n = len(self.x)
 
         # 1D array of uncertain numbers, no vectorization
-        z = [x - y for x, y in izip(self.x, self.y)]
-        zc = [x - y for x, y in izip(self.xc, self.yc)]
+        z = [x - y for x, y in zip(self.x, self.y)]
+        zc = [x - y for x, y in zip(self.xc, self.yc)]
         za = self.xa - self.ya
         zca = self.xca - self.yca
         for i in range(n):
@@ -921,8 +937,8 @@ class TestUncertainArray(unittest.TestCase):
         # 1D array of uncertain numbers, with vectorization
         # also switch the subtraction order to be y - x
         for m in range(n):
-            z = [y - x for y, x in izip(self.y[m:], self.x[m:])]
-            zc = [y - x for y, x in izip(self.yc[m:], self.xc[m:])]
+            z = [y - x for y, x in zip(self.y[m:], self.x[m:])]
+            zc = [y - x for y, x in zip(self.yc[m:], self.xc[m:])]
             za = self.ya[m:] - self.xa[m:]
             zca = self.yca[m:] - self.xca[m:]
             for i in range(n-m):
@@ -1045,7 +1061,7 @@ class TestUncertainArray(unittest.TestCase):
 
         # check subtraction with a list -> UncertainArray[ureal] - list
         my_list = list(range(n))
-        z = [x - val for x, val in izip(self.x, my_list)]
+        z = [x - val for x, val in zip(self.x, my_list)]
         za = self.xa - my_list
         for i in range(n):
             self.assertTrue(equivalent(z[i].x, za[i].x))
@@ -1053,7 +1069,7 @@ class TestUncertainArray(unittest.TestCase):
 
         # check subtraction with a list -> UncertainArray[ucomplex] - list
         my_list = [1+3j, 5j, -3+2.2j, 0.1+0.4j, 8., 1.9+3.4j]
-        zc = [x - val for x, val in izip(self.xc, my_list)]
+        zc = [x - val for x, val in zip(self.xc, my_list)]
         zca = self.xca - my_list
         for i in range(n):
             self.assertTrue(equivalent_complex(zc[i].x, zca[i].x))
@@ -1062,7 +1078,7 @@ class TestUncertainArray(unittest.TestCase):
 
         # check subtraction with a list -> list - UncertainArray[ureal]
         my_list = list(range(n))
-        z = [val - x for val, x in izip(my_list, self.x)]
+        z = [val - x for val, x in zip(my_list, self.x)]
         za = my_list - self.xa
         for i in range(n):
             self.assertTrue(equivalent(z[i].x, za[i].x))
@@ -1070,7 +1086,7 @@ class TestUncertainArray(unittest.TestCase):
 
         # check subtraction with a list -> list - UncertainArray[ucomplex]
         my_list = [3.1-2.3j, 4+5j, 3.2+7.3j, 5.1-0.4j, 0.1, 6.1+3.7j]
-        zc = [val - x for val, x in izip(my_list, self.xc)]
+        zc = [val - x for val, x in zip(my_list, self.xc)]
         zca = my_list - self.xca
         for i in range(n):
             self.assertTrue(equivalent_complex(zc[i].x, zca[i].x))
@@ -1096,7 +1112,7 @@ class TestUncertainArray(unittest.TestCase):
         n = len(self.x)
 
         # x * y
-        z = [x * y for x, y in izip(self.x, self.y)]
+        z = [x * y for x, y in zip(self.x, self.y)]
         za = self.xa * self.ya
         for i in range(n):
             self.assertTrue(equivalent(z[i].x, za[i].x))
@@ -1117,7 +1133,7 @@ class TestUncertainArray(unittest.TestCase):
         za = self.xa / self.ya
 
         # x / y
-        z = [x / y for x, y in izip(self.x, self.y)]
+        z = [x / y for x, y in zip(self.x, self.y)]
         for i in range(n):
             self.assertTrue(equivalent(z[i].x, za[i].x))
             self.assertTrue(equivalent(z[i].u, za[i].u))
@@ -1200,37 +1216,37 @@ class TestUncertainArray(unittest.TestCase):
         self.assertTrue(not np.array_equal(self.xa, self.ya))
 
         # == element-wise
-        z = [x == y for x, y in izip(self.x, self.y)]
+        z = [x == y for x, y in zip(self.x, self.y)]
         za = np.equal(self.xa, self.ya)
         for i in range(n):
             self.assertTrue(z[i] == za[i])
 
         # != element-wise
-        z = [x != y for x, y in izip(self.x, self.y)]
+        z = [x != y for x, y in zip(self.x, self.y)]
         za = np.not_equal(self.xa, self.ya)
         for i in range(n):
             self.assertTrue(z[i] == za[i])
 
         # < element-wise
-        z = [x < y for x, y in izip(self.x, self.y)]
+        z = [x < y for x, y in zip(self.x, self.y)]
         za = np.less(self.xa, self.ya)
         for i in range(n):
             self.assertTrue(z[i] == za[i])
 
         # <= element-wise
-        z = [x <= y for x, y in izip(self.x, self.y)]
+        z = [x <= y for x, y in zip(self.x, self.y)]
         za = np.less_equal(self.xa, self.ya)
         for i in range(n):
             self.assertTrue(z[i] == za[i])
 
         # > element-wise
-        z = [x > y for x, y in izip(self.x, self.y)]
+        z = [x > y for x, y in zip(self.x, self.y)]
         za = np.greater(self.xa, self.ya)
         for i in range(n):
             self.assertTrue(z[i] == za[i])
 
         # >= element-wise
-        z = [x >= y for x, y in izip(self.x, self.y)]
+        z = [x >= y for x, y in zip(self.x, self.y)]
         za = np.greater_equal(self.xa, self.ya)
         for i in range(n):
             self.assertTrue(z[i] == za[i])
@@ -1566,7 +1582,7 @@ class TestUncertainArray(unittest.TestCase):
         xa = uarray(x)
         ya = uarray(y)
         n = len(x)
-        z = [atan2(v1, v2) for v1, v2 in izip(x, y)]
+        z = [atan2(v1, v2) for v1, v2 in zip(x, y)]
 
         # call np.arctan2 
         za = np.arctan2(xa, ya)
@@ -1652,8 +1668,8 @@ class TestUncertainArray(unittest.TestCase):
         n = len(self.x)
 
         # use the "**" syntax -> UncertainArray ** UncertainArray
-        z = [x ** y for x, y in izip(self.x, self.y)]
-        zc = [x ** y for x, y in izip(self.xc, self.yc)]
+        z = [x ** y for x, y in zip(self.x, self.y)]
+        zc = [x ** y for x, y in zip(self.xc, self.yc)]
         za = self.xa ** self.ya
         zca = self.xca ** self.yca
         for i in range(n):
@@ -1708,7 +1724,7 @@ class TestUncertainArray(unittest.TestCase):
                 self.assertTrue(equivalent(zc[i].u.imag, zca[i].u.imag))
 
         # use GTC.core.pow -> UncertainArray ** UncertainArray
-        z = [pow(x, y) for x, y in izip(self.x, self.y)]
+        z = [pow(x, y) for x, y in zip(self.x, self.y)]
         za = pow(self.xa, self.ya)
         for i in range(n):
             self.assertTrue(equivalent(z[i].x, za[i].x))

--- a/test/test_uncertain_complex.py
+++ b/test/test_uncertain_complex.py
@@ -2,11 +2,7 @@ import re
 import unittest
 import numbers
 import sys
-
-if sys.version_info[0] < 3:
-    from operator import div  # Python 2
-else:
-    from operator import truediv as div
+from operator import truediv as div
 
 import numpy
 

--- a/test/test_uncertain_real.py
+++ b/test/test_uncertain_real.py
@@ -1,5 +1,6 @@
 import re
 import unittest
+
 import numpy
 
 from GTC import *

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -1,12 +1,5 @@
 import unittest
 import copy
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
-
-TOL = 1E-13
-DIGITS = 13
 
 from GTC.vector import (
     Vector,
@@ -18,6 +11,10 @@ from GTC.vector import (
 )
 
 from testing_tools import *
+
+TOL = 1E-13
+DIGITS = 13
+
 
 #----------------------------------------------------------------------------
 # The index of a vector is an object that must have a `uid` attribute
@@ -119,7 +116,7 @@ class TestVector(unittest.TestCase):
 
         self.assertTrue(is_ordered(v2))
 
-        for i1,i2 in izip(v1.iterkeys(),v2.iterkeys()):
+        for i1,i2 in zip(v1.iterkeys(),v2.iterkeys()):
             self.assertEqual(i1.uid,i2.uid)
 
     def test_extend(self):

--- a/test/testing_tools.py
+++ b/test/testing_tools.py
@@ -1,9 +1,5 @@
 """
 """
-try:
-    from itertools import izip  # Python 2
-except ImportError:
-    izip = zip
 import math
 
 __all__ = (
@@ -26,7 +22,7 @@ def equivalent_sequence(u,m,tol=TOL):
     """
     assert len(u) == len(m), f"different lengths: {u} and {m}"
     OK = True
-    for u_i,m_i in izip(u,m):
+    for u_i,m_i in zip(u,m):
         OK &=  abs(u_i - m_i) < tol       
 
     if OK:
@@ -34,7 +30,7 @@ def equivalent_sequence(u,m,tol=TOL):
     else:
         print(f"Tolerance = {tol:G}")
         print("Differences: ")
-        for u_i,m_i in izip(u,m):
+        for u_i,m_i in zip(u,m):
             print(abs(u_i - m_i))
             
         raise AssertionError(f"'{u}' <> '{m}'")


### PR DESCRIPTION
* Remove Python 2 specific imports
* Remove imports that are not used in a module
* Organise imports by builtin, 3rd party, GTC
* Remove Python 2 builtin names (e.g., `izip`, `xrange`)
